### PR TITLE
KAS-1066 bump acmidm-login-service version to fix login problems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       - ./config/mocklogin:/config
     logging: *default-logging
   login:
-    image: kanselarij/acmidm-login-service:1.0.1
+    image: kanselarij/acmidm-login-service:1.0.2
     environment:
       MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
       MU_APPLICATION_AUTH_CLIENT_ID: "b1c78c1e-3c88-44f4-90fa-bebc5c5dc28d"
@@ -144,6 +144,7 @@ services:
       DEBUG_LOG_TOKENSETS: "true"
       LOG_SINK_URL: "http://sink"
       MU_APPLICATION_RESOURCE_BASE_URI: "http://kanselarij.vo.data.gift/"
+      REQUEST_TIMEOUT: 5000
     logging: *default-logging
     restart: always
   newsletter-service:


### PR DESCRIPTION
The new version of the login service has a higher timeout for the authentication request.