### PR TITLE
Bump mu-authorization to 0.6.0-beta.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       MU_SPARQL_ENDPOINT: "http://triplestore:8890/sparql"
     restart: always
   database:
-    image: semtech/mu-authorization:0.6.0-beta.2
+    image: semtech/mu-authorization:0.6.0-beta.3
     environment:
       MU_SPARQL_ENDPOINT: "http://triplestore:8890/sparql"
       # LOG_OUTGOING_SPARQL_QUERIES: "true"


### PR DESCRIPTION
The new version has some fixes to stabilize error recovery mode.  The build of this image is queued, should be ready by the time the PR gets reviewed.