### PR TITLE
Kas 1453 hotfix/template versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
     logging: *default-logging
     restart: always
   yggdrasil:
-    image: kanselarij/yggdrasil:1.1.2
+    image: kanselarij/yggdrasil:1.1.3
     environment:
       DIRECT_ENDPOINT: "http://triplestore:8890/sparql"
       RELOAD_ALL_DATA_ON_INIT: "false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
     logging: *default-logging
     restart: always
   agenda-sort-service:
-    image: kanselarij/agenda-sort-service:1.1.0
+    image: kanselarij/agenda-sort-service:1.1.1
     logging: *default-logging
     restart: always
   custom-subcases-service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
     logging: *default-logging
     restart: always
   file-bundling-service:
-    image: kanselarij/file-bundling-service:2.1.1
+    image: kanselarij/file-bundling-service:2.1.2
     volumes:
       - ./data/files:/share
     logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
   #   logging: *default-logging
   #   restart: always
   session-number-service:
-    image: kanselarij/session-number-service:1.0.1
+    image: kanselarij/session-number-service:1.0.2
     logging: *default-logging
     restart: always
   agenda-sort-service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
     logging: *default-logging
     restart: always
   custom-subcases-service:
-    image: kanselarij/custom-subcases-service:1.0.0
+    image: kanselarij/custom-subcases-service:1.0.1
     logging: *default-logging
     restart: always
   agenda-approve-service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,7 @@ services:
     logging: *default-logging
     restart: always
   minister-jurisdiction-service:
-    image: kanselarij/minister-jurisdiction-service:1.0.0
+    image: kanselarij/minister-jurisdiction-service:1.0.1
     logging: *default-logging
     restart: always
   yggdrasil:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,7 +156,7 @@ services:
     logging: *default-logging
     restart: always
   newsletter-service:
-    image: kanselarij/newsletter-service:1.0.8
+    image: kanselarij/newsletter-service:1.0.9
     logging: *default-logging
     restart: always
   user-management-service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
     logging: *default-logging
     restart: always
   file-bundling-service:
-    image: kanselarij/file-bundling-service:2.1.2
+    image: kanselarij/file-bundling-service:2.1.3
     volumes:
       - ./data/files:/share
     logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     logging: *default-logging
     restart: always
   agenda-approve-service:
-    image: kanselarij/agenda-approve-service:1.0.4
+    image: kanselarij/agenda-approve-service:1.0.5
     logging: *default-logging
     restart: always
   mocklogin:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,7 +197,7 @@ services:
     logging: *default-logging
     restart: always
   database-healthcheck:
-    image: kanselarij/database-healthcheck:1.0.1
+    image: kanselarij/database-healthcheck:1.0.2
     logging: *default-logging
     restart: always
   lazy-loading-service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,7 +193,7 @@ services:
     logging: *default-logging
     restart: always
   file-bundling-job-creation-service:
-    image: kanselarij/file-bundling-job-creation-service:0.1.3
+    image: kanselarij/file-bundling-job-creation-service:0.1.4
     logging: *default-logging
     restart: always
   database-healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
     logging: *default-logging
     restart: always
   user-management-service:
-    image: kanselarij/user-management-service:1.0.1
+    image: kanselarij/user-management-service:1.0.2
     environment:
       MU_APPLICATION_RESOURCE_BASE_URI: "http://kanselarij.vo.data.gift/"
     logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,6 +201,6 @@ services:
     logging: *default-logging
     restart: always
   lazy-loading-service:
-    image: kanselarij/lazy-loading-service:1.0.0
+    image: kanselarij/lazy-loading-service:1.0.1
     logging: *default-logging
     restart: always


### PR DESCRIPTION
Since most of our services didn't use a tagged version of their template image, "random" updates there (beta releases etc) cause our services to build with an unwanted template version. This PR includes version bumps for services that now depend on a tagged template version