### PR TITLE
KAS-1221: migrate themes from procedurestap and agendapunt to kort bestek

### DIFF
--- a/config/migrations/20200407123000-move-agendaitem-themes.sparql
+++ b/config/migrations/20200407123000-move-agendaitem-themes.sparql
@@ -1,0 +1,23 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX dbpedia: <http://dbpedia.org/ontology/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT {
+  GRAPH ?g {
+    ?newsletterInfo dct:subject ?theme.
+  }
+}  WHERE {
+  GRAPH ?g {
+    ?subcase a dbpedia:UnitOfWork .
+    ?subcase besluitvorming:isGeagendeerdVia ?agendapunt.
+    ?agendapunt a besluit:Agendapunt .
+    ?agendapunt ext:agendapuntSubject ?theme.
+    ?subcase prov:generated ?newsletterInfo .
+    ?newsletterInfo a besluitvorming:NieuwsbriefInfo.
+    FILTER NOT EXISTS {
+      ?newsletterInfo dct:subject ?somesubject.
+    }
+  }
+}

--- a/config/migrations/20200407123100-move-subcase-themes.sparql
+++ b/config/migrations/20200407123100-move-subcase-themes.sparql
@@ -1,0 +1,21 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX dbpedia: <http://dbpedia.org/ontology/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT {
+  GRAPH ?g {
+    ?newsletterInfo dct:subject ?theme.
+  }
+}  WHERE {
+  GRAPH ?g {
+    ?subcase a dbpedia:UnitOfWork .
+    ?subcase dct:subject ?theme .
+    ?subcase prov:generated ?newsletterInfo .
+    ?newsletterInfo a besluitvorming:NieuwsbriefInfo.
+    FILTER NOT EXISTS {
+      ?newsletterInfo dct:subject ?somesubject.
+    }
+  }
+}

--- a/config/migrations/20200407123200-remove-old-themes.sparql
+++ b/config/migrations/20200407123200-remove-old-themes.sparql
@@ -1,0 +1,19 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX dbpedia: <http://dbpedia.org/ontology/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+DELETE {
+  GRAPH ?g {
+    ?subcase dct:subject ?subcasetheme .
+    ?agendapunt ext:agendapuntSubject ?agendaitemtheme.
+  }
+}  WHERE {
+  GRAPH ?g {
+    ?subcase a dbpedia:UnitOfWork .
+    ?subcase dct:subject ?subcasetheme .
+    ?agendapunt a besluit:Agendapunt .
+    ?agendapunt ext:agendapuntSubject ?agendaitemtheme.
+  }
+}

--- a/config/resources/publicatie-domain.lisp
+++ b/config/resources/publicatie-domain.lisp
@@ -1,5 +1,5 @@
 (define-resource publication ()
-  :class (s-prefix "besluitvorming:Publicatie") 
+  :class (s-prefix "besluitvorming:Publicatie")
   :properties `((:nuber-of-words :number ,(s-prefix "besluitvorming:aantalWoorden"))
                 (:digital :boolean ,(s-prefix "besluitvorming:digitaal"))
                 (:number :string ,(s-prefix "adms:identifier"))
@@ -16,14 +16,14 @@
              (mandatee :via ,(s-prefix "besluitvorming:heeftBevoegde") ;; NOTE: used mandataris instead of agent
                        :as "mandatee"))
   :has-many `((remark :via ,(s-prefix "rdfs:comment")
-                      :as "remarks") 
+                      :as "remarks")
               (decision :via ,(s-prefix "besluitvorming:isGerealiseerdDoor")
                         :inverse t
                         :as "decisions"))
   :resource-base (s-url "http://kanselarij.vo.data.gift/id/publicaties/")
   :features '(include-uri)
   :on-path "publications")
-  
+
 (define-resource publication-state ()
   :class (s-prefix "besluitvorming:PublicatieStatus") ;; NOTE: Should be subclass of besluitvorming:Status (mu-cl-resources reasoner workaround)
   :properties `((:date :datetime ,(s-prefix "besluitvorming:statusdatum")))
@@ -71,7 +71,7 @@
   :on-path "remarks")
 
 (define-resource newsletter-info ()
-  :class (s-prefix "besluitvorming:NieuwsbriefInfo") 
+  :class (s-prefix "besluitvorming:NieuwsbriefInfo")
   :properties `((:text                  :string   ,(s-prefix "besluitvorming:inhoud"))
                 (:richtext              :string   ,(s-prefix "ext:htmlInhoud"))
                 (:subtitle              :string   ,(s-prefix "dbpedia:subtitle"))
@@ -91,7 +91,7 @@
                                         :as "meeting")
              (user                      :via      ,(s-prefix "ext:modifiedBy")
                                         :as "modified-by"))
-  :has-many `((theme                    :via      ,(s-prefix "ext:themesOfSubcase")
+  :has-many `((theme                    :via      ,(s-prefix "dct:subject")
                                         :as "themes")
               (document                 :via      ,(s-prefix "ext:documentenVoorPublicatie")
                                         :as "document-versions"))
@@ -116,7 +116,7 @@
   :on-path "themes")
 
 (define-resource mail-campaign ()
-  :class (s-prefix "ext:MailCampagne") 
+  :class (s-prefix "ext:MailCampagne")
   :properties `((:campaign-id       :string   ,(s-prefix "ext:campagneId"))
                 (:campaign-web-id   :string   ,(s-prefix "ext:campagneWebId"))
                 (:archive-url       :string   ,(s-prefix "ext:voorbeeldUrl"))


### PR DESCRIPTION
- changed predicate for themes on newsletter info
- moved themes from agendaitems to newsletter-info if no themes present there
- then moved themes from subcase to newsletter-info if no themes present there
- then removed all themes from subcase and agendaitem