### PR TITLE
KAS-1416 add yggdrasil environment value for tests

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -26,4 +26,10 @@ services:
   file-bundling-service:
     volumes:
       - ./testdata/files:/share
-
+  # The DELTA_TIMEOUT is the value that yggdrasil waits between runs in milliseconds
+  # Default is 5 minutes but results in 10 minutes between runs  
+  yggdrasil:
+    environment:
+      NODE_ENV: "development"
+      DEBUG: "true"
+      DELTA_TIMEOUT: 10000


### PR DESCRIPTION
Deze overrides zijn enkel voor de cypress testen.

De image van yggdrasil gaat bij `drc up -d` automatisch opnieuw starten met die nieuwe parameter bij het runnen van de testen

