### PR TITLE
KAS-1758 added publicSince to document-domain-lisp

### DIFF
--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -24,7 +24,6 @@
                 (:modified              :datetime ,(s-prefix "dct:modified"))
                 (:confidential          :boolean  ,(s-prefix "ext:vertrouwelijk"))
                 (:public-since          :boolean  ,(s-prefix "ext:publiekSinds")))
-
   :has-one `((access-level               :via ,(s-prefix "ext:toegangsniveauVoorDocumentVersie")
                                         :as "access-level")
             (file                       :via      ,(s-prefix "ext:file")

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -23,7 +23,7 @@
                 (:created               :datetime ,(s-prefix "dct:created"))
                 (:modified              :datetime ,(s-prefix "dct:modified"))
                 (:confidential          :boolean  ,(s-prefix "ext:vertrouwelijk"))
-                (:public-since          :boolean  ,(s-prefix "ext:publiekSinds")))
+                (:public-since          :datetime  ,(s-prefix "ext:publiekSinds")))
   :has-one `((access-level               :via ,(s-prefix "ext:toegangsniveauVoorDocumentVersie")
                                         :as "access-level")
             (file                       :via      ,(s-prefix "ext:file")

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -19,10 +19,12 @@
 
 (define-resource document ()
   :class (s-prefix "dossier:Stuk")
-  :properties `((:name                 :string   ,(s-prefix "dct:title"))
+  :properties `((:name                  :string   ,(s-prefix "dct:title"))
                 (:created               :datetime ,(s-prefix "dct:created"))
                 (:modified              :datetime ,(s-prefix "dct:modified"))
-                (:confidential          :boolean  ,(s-prefix "ext:vertrouwelijk")))
+                (:confidential          :boolean  ,(s-prefix "ext:vertrouwelijk"))
+                (:public-since          :boolean  ,(s-prefix "ext:publiekSinds")))
+
   :has-one `((access-level               :via ,(s-prefix "ext:toegangsniveauVoorDocumentVersie")
                                         :as "access-level")
             (file                       :via      ,(s-prefix "ext:file")


### PR DESCRIPTION
# KAS-1758: Added publicSince to document-domain-lisp

## Changed:
- `document-domain-lisp`
