### PR TITLE
KAS-1286: Registreren zittingnummer - DEVELOPMENT

### DIFF
--- a/config/migrations/20200731104310-meeting-numberrepresentation.sparql
+++ b/config/migrations/20200731104310-meeting-numberrepresentation.sparql
@@ -1,0 +1,23 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+    GRAPH ?g {
+        ?vergaderactiviteit ext:numberRepresentation ?numberToInsert .
+    }
+}
+WHERE {
+ SELECT ?g, ?vergaderactiviteit, ?vergaderActiviteitJaar, ?vergaderActiviteitNummer, ?numberToInsert WHERE {
+     GRAPH ?g {
+     ?vergaderactiviteit a besluit:Vergaderactiviteit .
+     ?vergaderactiviteit besluit:geplandeStart ?vergaderActiviteitJaar .
+     ?vergaderactiviteit adms:identifier ?vergaderActiviteitNummer .
+
+     BIND ((CONCAT(SUBSTR(str(?vergaderActiviteitJaar),1,4))) AS ?parsedYear)
+     BIND (CONCAT("VR PV ", ?parsedYear) as ?parts)
+     BIND (CONCAT(?parts, "/") as ?part1MetSlash)
+     BIND (CONCAT(?part1MetSlash, ?vergaderActiviteitNummer) as ?numberToInsert)
+   }
+ }
+}

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -192,7 +192,8 @@
                 (:number                :number   ,(s-prefix "adms:identifier"))
                 (:is-final              :boolean  ,(s-prefix "ext:finaleZittingVersie")) ;; 2019-01-09: Also see note on agenda "is-final". "ext:finaleZittingVersie" == true means "agenda afgesloten" but not at a version level
                 (:kind                  :url      ,(s-prefix "dct:type"))
-                (:extra-info            :string   ,(s-prefix "ext:extraInfo"))) 
+                (:extra-info            :string   ,(s-prefix "ext:extraInfo"))
+                (:number-representation :string   ,(s-prefix "ext:numberRepresentation")))
   :has-many `((agenda                   :via      ,(s-prefix "besluitvorming:isAgendaVoor")
                                         :inverse t
                                         :as "agendas")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-extended-logging:
     max-file: "20"
 services:
   frontend:
-    image: kanselarij/frontend-kaleidos:3.0.8
+    image: kanselarij/frontend-kaleidos:3.0.9
     links:
       - identifier:backend
     logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-extended-logging:
     max-file: "20"
 services:
   frontend:
-    image: kanselarij/frontend-kaleidos:3.0.9
+    image: kanselarij/frontend-kaleidos:3.0.10
     links:
       - identifier:backend
     logging: *default-logging


### PR DESCRIPTION
# KAS-1286: Registreren zittingnummer 

In deze PR, voorzien we een nieuw weergaveveld voor het zittingnummer dat ingevuld kan worden in de frontend.
Om de oude data aan te passen is er een migratiequery geschreven die de waardes aanpast. `20200731104310-meeting-numberrepresentation.sparql`.

Data voor de migratie:
```sparql
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX adms: <http://www.w3.org/ns/adms#>
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>

SELECT ?vergaderactiviteit ?vergaderActiviteitJaar ?vergaderActiviteitNummer WHERE {
     ?vergaderactiviteit a besluit:Vergaderactiviteit .
     ?vergaderactiviteit besluit:geplandeStart ?vergaderActiviteitJaar .
     ?vergaderactiviteit adms:identifier ?vergaderActiviteitNummer .
}
```
![image](https://user-images.githubusercontent.com/11557630/89018430-2adea200-d31c-11ea-90fb-862b024ef4e7.png)

Data na de migratie:
```sparql
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX adms: <http://www.w3.org/ns/adms#>
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>

SELECT ?vergaderactiviteit ?vergaderActiviteitJaar ?vergaderActiviteitNummer ?visualRepresentation WHERE {
     ?vergaderactiviteit a besluit:Vergaderactiviteit .
     ?vergaderactiviteit besluit:geplandeStart ?vergaderActiviteitJaar .
     ?vergaderactiviteit adms:identifier ?vergaderActiviteitNummer .
     ?vergaderactiviteit ext:numberRepresentation ?visualRepresentation .
}
```
![image](https://user-images.githubusercontent.com/11557630/89018601-67aa9900-d31c-11ea-84f8-b34648dc039b.png)

