### PR TITLE
KAS-1642: Opkuis model: gebruik van URI aanpassen naar URL

### DIFF
--- a/config/migrations/20200803144710-migratie-formallyok-from-uri-to-url.sparql
+++ b/config/migrations/20200803144710-migratie-formallyok-from-uri-to-url.sparql
@@ -1,6 +1,5 @@
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 DELETE{
     GRAPH ?g {

--- a/config/migrations/20200803144710-migratie-formallyok-from-uri-to-url.sparql
+++ b/config/migrations/20200803144710-migratie-formallyok-from-uri-to-url.sparql
@@ -1,0 +1,22 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE{
+    GRAPH ?g {
+          ?agendapunt besluitvorming:formeelOK ?formallyOk .
+    }
+}
+INSERT {
+    GRAPH ?g {
+         ?agendapunt besluitvorming:formeelOK ?newformallyOk  .
+    }
+} WHERE{
+        SELECT ?g, ?agendapunt, ?formallyOk, ?newformallyOk WHERE {
+            GRAPH ?g {
+                ?agendapunt a besluit:Agendapunt .
+                ?agendapunt besluitvorming:formeelOK ?formallyOk.
+                BIND(URI(?formallyOk) as ?newformallyOk)
+            }
+        }
+}

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -4,7 +4,7 @@
                 (:title        :string     ,(s-prefix "dct:title"))
                 (:serialnumber :string    ,(s-prefix "besluitvorming:volgnummer"))
                 (:created     :date       ,(s-prefix "dct:created"))
-                ; (:agendatype  :uri        ,(s-prefix "dct:type")) // Currently not implemented ( https://test.data.vlaanderen.be/doc/applicatieprofiel/besluitvorming/#Agenda )
+                ; (:agendatype  :url      ,(s-prefix "dct:type")) // Currently not implemented ( https://test.data.vlaanderen.be/doc/applicatieprofiel/besluitvorming/#Agenda )
                 (:modified    :datetime   ,(s-prefix "dct:modified")))
   :has-one `((meeting         :via        ,(s-prefix "besluitvorming:isAgendaVoor")
                               :as "created-for")
@@ -54,7 +54,7 @@
                 (:short-title         :string   ,(s-prefix "dct:alternative"))
                 (:title               :string   ,(s-prefix "dct:title"))
                 (:modified            :datetime   ,(s-prefix "ext:modified"))
-                (:formally-ok         :uri  ,(s-prefix "besluitvorming:formeelOK")) ;; NOTE: What is the URI of property 'formeelOK'? Made up besluitvorming:formeelOK
+                (:formally-ok         :url  ,(s-prefix "besluitvorming:formeelOK")) ;; NOTE: What is the URI of property 'formeelOK'? Made up besluitvorming:formeelOK
                 (:show-as-remark      :boolean  ,(s-prefix "ext:wordtGetoondAlsMededeling"))
                 (:is-approval         :boolean  ,(s-prefix "ext:isGoedkeuringVanDeNotulen"))) ;; NOTE: What is the URI of property 'titelPersagenda'? Made up besluitvorming:titelPersagenda
   :has-one `((agendaitem              :via      ,(s-prefix "besluit:aangebrachtNa")

--- a/config/resources/job-domain.lisp
+++ b/config/resources/job-domain.lisp
@@ -1,7 +1,7 @@
 (define-resource file-bundling-job ()
   :class (s-prefix "ext:FileBundlingJob") ; "cogs:Job"
   :properties `((:created       :datetime  ,(s-prefix "dct:created"))
-                (:status        :uri       ,(s-prefix "ext:status"))
+                (:status        :url       ,(s-prefix "ext:status"))
                 (:time-started  :datetime  ,(s-prefix "prov:startedAtTime"))
                 (:time-ended    :datetime  ,(s-prefix "prov:endedAtTime"))
   )


### PR DESCRIPTION
# 🧹 KAS-1642: Opkuis model: gebruik van URI aanpassen naar URL

In deze PR hebben we een migratie geschreven voor het migreren van de `formally-ok` property op een `agendapunt`.

## ✏️ What has changed:
| File  | Property  | Before  | After  | Migrated  | Migration-file |
|:-:|:-:|:-:|:-:|:-:|:-:|
|  `config/resources/besluit-domain.lisp` | `agendatype`  | `:uri`  | `:url`  | ❌  |  |
|  `config/resources/besluit-domain.lisp` | `formally-ok`  | `:uri`  | `:url`  | ✅  | `config/migrations/20200803144710-migratie-formallyok-from-uri-to-url.sparql` |
|  `config/resources/job-domain.lisp` | `status `  | `:uri`  | `:url`  | ❌  | |

## 🧪  To Test
- Testen op de test dataset zodat je je database niet kapot maakt:

Je kan de output zien door de volgende query te runnen nadat de migratie gelopen heeft:
```sparql
PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>

SELECT ?agendapunt ?formallyOk WHERE {
         ?agendapunt a besluit:Agendapunt .
         ?agendapunt besluitvorming:formeelOK ?formallyOk.
}
```

**Before:**
![image](https://user-images.githubusercontent.com/11557630/89185506-9f267900-d59a-11ea-87fd-d59dcc0631b1.png)

**After:**
![image](https://user-images.githubusercontent.com/11557630/89185274-448d1d00-d59a-11ea-830d-22a8734e8aed.png)
