### PR TITLE
KAS-1426: remove announcement model

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -64,7 +64,6 @@ defmodule Acl.UserGroups.Config do
       "http://mu.semte.ch/vocabularies/ext/ThemaCode",
       "http://mu.semte.ch/vocabularies/ext/Thema",
       "http://mu.semte.ch/vocabularies/ext/SysteemNotificatieType",
-      "https://data.vlaanderen.be/ns/besluitvorming#Mededeling", # TODO: why is this https ?
       "http://mu.semte.ch/vocabularies/ext/ToegangsniveaCode", # TODO: fix missing "u"
       "http://data.vlaanderen.be/ns/mandaat#Mandaat",
       "http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode",
@@ -108,7 +107,6 @@ defmodule Acl.UserGroups.Config do
       "http://xmlns.com/foaf/0.1/OnlineAccount",
       "http://xmlns.com/foaf/0.1/Person",
       "http://xmlns.com/foaf/0.1/Group",
-      "https://data.vlaanderen.be/ns/besluitvorming#Mededeling", # TODO: why is this https ?
       "http://mu.semte.ch/vocabularies/ext/ToegangsniveauCode",
       "http://data.vlaanderen.be/ns/mandaat#Mandaat",
       "http://mu.semte.ch/vocabularies/ext/BeleidsdomeinCode",

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -62,9 +62,6 @@ defmodule Dispatcher do
   match "/agendaitems/*path", @any do
     Proxy.forward conn, path, "http://cache/agendaitems/"
   end
-  match "/announcements/*path", @any do
-    Proxy.forward conn, path, "http://cache/announcements/"
-  end
   match "/decisions/*path", @any do
     Proxy.forward conn, path, "http://cache/decisions/"
   end

--- a/config/migrations/20200824090010-delete-announcement-relation.sparql
+++ b/config/migrations/20200824090010-delete-announcement-relation.sparql
@@ -1,0 +1,11 @@
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+
+DELETE{
+    GRAPH ?g {
+       ?announcement a besluitvorming:Mededeling .
+    }
+ } WHERE{
+    GRAPH ?g {
+       ?announcement a besluitvorming:Mededeling .
+    }
+ }

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -20,9 +20,7 @@
   :has-many `((agendaitem     :via        ,(s-prefix "dct:hasPart")
                               :as "agendaitems")
               (document       :via        ,(s-prefix "besluitvorming:heeftBijlage")
-                              :as "attachments")
-             (announcement    :via        ,(s-prefix "ext:mededeling")
-                              :as "announcements"))
+                              :as "attachments"))
   :resource-base (s-url "http://kanselarij.vo.data.gift/id/agendas/")
   :features '(include-uri)
   :on-path "agendas")
@@ -99,22 +97,6 @@
                             :as "agendaitem"))
   :resource-base (s-url "http://kanselarij.vo.data.gift/id/goedkeuringen/")
   :on-path "approvals")
-
-;; NOTE: created zit niet in de database, modified wel
-  (define-resource announcement ()
-  :class (s-prefix "besluitvorming:Mededeling")
-  :properties `((:title         :string ,(s-prefix "ext:title"))
-                (:text          :string ,(s-prefix "ext:text"))
-                (:created       :datetime ,(s-prefix "ext:created"))
-                (:modified      :datetime ,(s-prefix "ext:modified")))
-  :has-one `((agenda            :via ,(s-prefix "ext:mededeling")
-                                :inverse t
-                                :as "agenda"))
-  :has-many `((document         :via ,(s-prefix "ext:mededelingBevatDocumentversie")
-                                :as "document-versions"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/mededelingen/")
-  :on-path "announcements")
-
 
 (define-resource decision ()
   :class (s-prefix "besluit:Besluit") ;; NOTE: Took over all properties from document instead of subclassing (mu-cl-resources workaround)

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -50,9 +50,6 @@
             (agendaitem                 :via ,(s-prefix "ext:bevatReedsBezorgdAgendapuntDocumentversie")
                                         :inverse t
                                         :as "agendaitem")
-            (announcement               :via ,(s-prefix "ext:mededelingBevatDocumentversie")
-                                        :inverse t
-                                        :as "announcement")
             (newsletter-info            :via ,(s-prefix "ext:documentenVoorPublicatie")
                                         :inverse t
                                         :as "newsletter")


### PR DESCRIPTION
# KAS-1426: remove announcement model
In deze PR hebben we de occurrence van announcement verwijderd

## What has been done
- @ValenberghsSven en ik hebben alle relaties afgechecked om te weten of de relaties gebruikt worden of niet.
- Migratie geschreven voor het verwijderen van de relatie 

## Related changes:
- PR frontend: https://github.com/kanselarij-vlaanderen/kaleidos-frontend/pull/476
- PR Yggdrasil: https://github.com/kanselarij-vlaanderen/yggdrasil/pull/17


