### PR TITLE
KAS-1809 remove formallyOk from subcase

### DIFF
--- a/config/migrations/20200825143000-remove-formallyOk-subcase.sparql
+++ b/config/migrations/20200825143000-remove-formallyOk-subcase.sparql
@@ -1,0 +1,13 @@
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX dbpedia:  <http://dbpedia.org/ontology/>
+
+DELETE{
+  GRAPH ?g {
+    ?subcase besluitvorming:formeelOK ?formallyOk.
+  }
+} WHERE{
+  GRAPH ?g {
+    ?subcase a dbpedia:UnitOfWork ;
+             besluitvorming:formeelOK ?formallyOk.
+  }
+}

--- a/config/resources/dossier-domain.lisp
+++ b/config/resources/dossier-domain.lisp
@@ -30,7 +30,6 @@
                 (:subcase-identifier  :string ,(s-prefix "ext:procedurestapNummer"))
                 (:is-archived         :boolean   ,(s-prefix "ext:isProcedurestapGearchiveerd"))
                 (:confidential        :boolean   ,(s-prefix "ext:vertrouwelijk"))
-                (:formally-ok         :boolean  ,(s-prefix "besluitvorming:formeelOK")) ;; NOTE: What is the URI of property 'formeelOK'? Made up besluitvorming:formeelOK
                 (:subcase-name        :string ,(s-prefix "ext:procedurestapNaam"))
                 (:created             :datetime ,(s-prefix "dct:created"))
                 (:modified            :datetime ,(s-prefix "ext:modified"))


### PR DESCRIPTION
KAS-1422
Reduce duplicate data in models agendaitem and subcase

subtask KAS-1809:
remove formallyOk from subcase model
reasoning: FormallyOk status on subcase is no longer relevant, not shown or adjustable in frontend.

### What has changed:

config/migrations/20200825143000-remove-formallyOk-subcase.sparql
- added migration to delete formallyOk from subcases

config/resources/dossier-domain.lisp:
- Removed formallyOk from subcase model

### See linked PR

https://github.com/kanselarij-vlaanderen/kaleidos-frontend/pull/480
