### PR TITLE
KAS-1683: Remove unused predicate from config

### DIFF
--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -18,9 +18,7 @@
                                :inverse t
                                :as "next-version"))
   :has-many `((agendaitem     :via        ,(s-prefix "dct:hasPart")
-                              :as "agendaitems")
-              (piece       :via        ,(s-prefix "besluitvorming:heeftBijlage")
-                              :as "attachments"))
+                              :as "agendaitems"))
   :resource-base (s-url "http://kanselarij.vo.data.gift/id/agendas/")
   :features '(include-uri)
   :on-path "agendas")


### PR DESCRIPTION
Title says it all.
Query to verify non-existence on prod:
```
PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>

SELECT DISTINCT ?b {
    GRAPH ?g {
        ?agenda a besluitvorming:Agenda .
        ?agenda besluitvorming:heeftBijlage ?b .
    }
}
LIMIT 500
```