### PR TITLE
Reduce amount of produced logs in production env

### DIFF
--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -12,9 +12,12 @@
   "when non-nil, all paginated listings will contain the number
    of responses in the result object's meta.")
 (defparameter *max-group-sorted-properties* nil)
+(defparameter sparql:*query-log-types* nil)
+
 (in-package :sparql)
 (defparameter *experimental-no-application-graph-for-sudo-select-queries* t)
 (defparameter *no-application-graph-for-sudo-select-queries* t)
+
 (in-package :mu-cl-resources)
 (read-domain-file "besluit-domain.lisp")
 (read-domain-file "besluitvorming-domain.lisp")

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -17,6 +17,17 @@ services:
     restart: "no"
   database:
     restart: "no"
+    environment:
+      LOG_OUTGOING_SPARQL_QUERIES: "true"
+      INSPECT_OUTGOING_SPARQL_QUERIES: "false"
+      LOG_INCOMING_SPARQL_QUERIES: "true"
+      INSPECT_INCOMING_SPARQL_QUERIES: "false"
+      LOG_ACCESS_RIGHTS: "true"
+      INSPECT_ACCESS_RIGHTS_PROCESSING: "true"
+      LOG_DELTA_MESSAGES: "true"
+      LOG_DELTA_CLIENT_COMMUNICATION: "true"
+      LOG_TEMPLATE_MATCHER_PERFORMANCE: "false"
+      LOG_DATABASE_OVERLOAD_TICK: "false"
   triplestore:
     ports:
       - "8890:8890"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,18 +40,8 @@ services:
     image: semtech/mu-authorization:0.6.0-beta.4
     environment:
       MU_SPARQL_ENDPOINT: "http://triplestore:8890/sparql"
-      # LOG_OUTGOING_SPARQL_QUERIES: "true"
-      # INSPECT_OUTGOING_SPARQL_QUERIES: "false"
-      # LOG_INCOMING_SPARQL_QUERIES: "true"
-      # INSPECT_INCOMING_SPARQL_QUERIES: "false"
-      # LOG_ACCESS_RIGHTS: "true"
-      # INSPECT_ACCESS_RIGHTS_PROCESSING: "true"
-      LOG_DELTA_MESSAGES: "true"
-      # LOG_DELTA_CLIENT_COMMUNICATION: "true"
-      # LOG_TEMPLATE_MATCHER_PERFORMANCE: "false"
       DATABASE_COMPATIBILITY: "Virtuoso"
       DATABASE_OVERLOAD_RECOVERY: "on"
-      #LOG_DATABASE_OVERLOAD_TICK: "on"
     volumes:
       - ./config/authorization:/config
     logging: *extended-logging


### PR DESCRIPTION
Reduce the amount of logs produces by `mu-cl-resources` and `mu-authorization` for a production environment. Also see this [jira-comment](https://kanselarij.atlassian.net/browse/KAS-1846?focusedCommentId=14104)