### PR TITLE
KAS-1849 Invert relationship & switch namespace

### DIFF
--- a/config/migrations/20201005161220-change-wrong-meeting-relationship-dir.sparql
+++ b/config/migrations/20201005161220-change-wrong-meeting-relationship-dir.sparql
@@ -1,6 +1,7 @@
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
 DELETE {
     GRAPH ?g {

--- a/config/migrations/20201005161220-change-wrong-meeting-relationship-dir.sparql
+++ b/config/migrations/20201005161220-change-wrong-meeting-relationship-dir.sparql
@@ -1,0 +1,21 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+
+DELETE {
+    GRAPH ?g {
+        ?meeting besluitvorming:isAangevraagdVoor ?sc .
+    }
+}
+INSERT {
+    GRAPH ?g {
+        ?sc ext:isAangevraagdVoor ?meeting .
+    }
+}
+WHERE {
+    GRAPH ?g {
+        ?sc a dossier:Procedurestap .
+        ?meeting a besluit:Vergaderactiviteit .
+        ?meeting besluitvorming:isAangevraagdVoor ?sc .
+    }
+}


### PR DESCRIPTION
[KAS-1849](https://kanselarij.atlassian.net/browse/KAS-1849?focusedCommentId=14108): invert relationship direction.
Note that this query looks for `besluitvorming:isAangevraagdVoor`. In the `besluitvorming` namespace that is, even though a previous migration brought this predicate to the `ext` namespace. This because the inverted relationship wasn't "caught" by the previous one.