### PR TITLE
Remove deprecated toon in kort bestek prop

### DIFF
--- a/config/migrations/20201001102638-remove-in-newsl-prop.sparql
+++ b/config/migrations/20201001102638-remove-in-newsl-prop.sparql
@@ -1,0 +1,14 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+DELETE {
+    GRAPH ?g {
+        ?ai ext:toonInKortBestek ?tikb .
+    }
+}
+WHERE {
+    GRAPH ?g {
+        ?ai a besluit:Agendapunt ;
+            ext:toonInKortBestek ?tikb .
+    }
+}

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -41,7 +41,6 @@
                 (:retracted           :boolean  ,(s-prefix "besluitvorming:ingetrokken")) ;; NOTE: What is the URI of property 'ingetrokken'? Made up besluitvorming:ingetrokken
                 (:priority            :number   ,(s-prefix "ext:prioriteit"))
                 (:for-press           :boolean  ,(s-prefix "ext:forPress"))
-                (:show-in-newsletter  :boolean  ,(s-prefix "ext:toonInKortBestek"))
                 (:record              :string   ,(s-prefix "besluitvorming:notulen")) ;; NOTE: What is the URI of property 'notulen'? Made up besluitvorming:notulen
                 (:title-press         :string   ,(s-prefix "besluitvorming:titelPersagenda"))
                 (:explanation         :string   ,(s-prefix "ext:toelichting"))


### PR DESCRIPTION
Goes together with frontend PR[#524]( https://github.com/kanselarij-vlaanderen/kaleidos-frontend/pull/524)

Nieuwe PR omdat er wat misgelopen is bij het mergen https://github.com/kanselarij-vlaanderen/kaleidos-project/pull/116