### PR TITLE
KAS-1943 delete agendaitems without agenda

### DIFF
--- a/config/migrations/20201030153700-correct-agendaitem-without-agenda.sparql
+++ b/config/migrations/20201030153700-correct-agendaitem-without-agenda.sparql
@@ -1,0 +1,26 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+DELETE {
+  GRAPH ?g  {
+    ?agendaitem ?p ?o .
+    ?s ?pp ?agendaitem .
+  }
+} WHERE {
+  GRAPH ?g  {
+    ?agendaitem a besluit:Agendapunt .
+    ?agendaitem ?p ?o .
+    ?s ?pp ?agendaitem .
+    {
+      SELECT DISTINCT ?agendaitem WHERE {
+        GRAPH ?g  {
+          ?agendaitem a besluit:Agendapunt .
+          ?subcase ^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt ?agendaitem .
+          ?subcase ext:isAangevraagdVoor ?meeting . 
+          FILTER NOT EXISTS { ?agenda dct:hasPart ?agendaitem . }
+        }
+      }
+    }
+  } 
+} 


### PR DESCRIPTION
Reden voor dit ticket:
"Doorklikken naar agenda vanuit procedurestap werkt niet"

Onderzoek uitgevoerd:
- er kwam een frontend error uit de "latestAgendaitem" computed van het agenda-activity model.
- agendaitem.get(agenda) gaf null.
- via agenda-activity gezien dat er 5 agendaitems waren, maar 2 ervan hebben geen agenda
- de gekoppelde zitting heeft maar 3 agendas, dus die 2 agendaitems lijken kapotte data te zijn.
- query gemaakt om te zoeken naar agendaitems zonder agenda (dct:hasPart)
- query aangepast om uit te zoeken welke zittingen er aan hangen .. agendaitem -> agenda-acitivity -> subcase -> meeting
```
PREFIX dct: <http://purl.org/dc/terms/>
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>

SELECT (COUNT(*)as ?agendaitems) WHERE {
  GRAPH ?g  {
    ?agendaitem a besluit:Agendapunt .
    ?subcase ^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt ?agendaitem .
    ?subcase ext:isAangevraagdVoor ?meeting . 
    FILTER NOT EXISTS { ?agenda dct:hasPart ?agendaitem . }
  }
}
```
- hier kwamen **384** resultaten uit
- query aangepast om te kijken over welke zittingen dit gaat
![image](https://user-images.githubusercontent.com/22245223/97731183-1e154a00-1ad5-11eb-92f0-aea367363088.png)
- alle vergaderingen van de query liggen in de periode 09/2019 - 11/2019
- Assumptie gemaakt: er zat een fout in onze agenda-approve service bij het deleten van de ontwerpagenda bij het afsluiten van een zitting. De delete van de agenda zelf is geslaagd, maar de agendapunten bestonden nog
Ofwel niet verwijderd (nog niet geimplementeerd) ofwel een fout in die query
- Oplossing: we moeten die agendapunten gaan verwijderen zoals de agenda-approve-service dat zou gedaan hebben.
- als test heb ik op accept 1 procedurestap met kapotte link bekeken en de query in migratie aangepast met subcase id.
- na delete van die 2 agendapunten was de data in ember ok, 3 items ipv 5 in de activity en alles lijkt nog correct te werken.
- Enkel search was niet ok, manuele queries triggeren geen updates
![image](https://user-images.githubusercontent.com/22245223/97734835-f83e7400-1ad9-11eb-8fc8-f3c4d51d4ad4.png)
