### PR TITLE
VAL-62 Bump mu-identifier to v1.9.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     logging: *default-logging
     restart: always
   identifier:
-    image: semtech/mu-identifier:1.8.1
+    image: semtech/mu-identifier:1.9.1
     logging: *default-logging
     restart: always
   dispatcher:


### PR DESCRIPTION
Bump mu-identifier to v1.9.1.

Release includes:
- logging flag for session id and allowed groups
- fix for process leak