### PR TITLE
Bump mu-authorization to v0.6.0-beta.6

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -306,6 +306,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/languages/"
   end
 
+  get "/recovery-status/*path", @any do
+    Proxy.forward conn, [], "http://database:8890/recovery-status/"
+  end
+
   match "_", %{ last_call: true } do
     send_resp( conn, 404, "Route not found.  See config/dispatcher.ex" )
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     logging: *default-logging
     restart: always
   database:
-    image: semtech/mu-authorization:0.6.0-beta.5
+    image: semtech/mu-authorization:0.6.0-beta.6
     environment:
       MU_SPARQL_ENDPOINT: "http://triplestore:8890/sparql"
       DATABASE_COMPATIBILITY: "Virtuoso"


### PR DESCRIPTION
- /recovery-status endpoint in JSON format
- fixes issues with escaping in DELETE/INSERT WHERE queries