### PR TITLE
KAS-2069: change publicationnumber type to number

### DIFF
--- a/config/resources/publicatie-domain.lisp
+++ b/config/resources/publicatie-domain.lisp
@@ -1,6 +1,6 @@
 (define-resource publication-flow ()
   :class (s-prefix "pub:Publicatieaangelegenheid")
-  :properties `((:publication-number  :string   ,(s-prefix "pub:publicatieNummer"))
+  :properties `((:publication-number  :number   ,(s-prefix "pub:publicatieNummer"))
                 (:translate-before    :datetime ,(s-prefix "pub:uitersteVertaling")) ;; in de subcase ?
                 (:publish-before      :datetime ,(s-prefix "pub:uiterstePublicatie")) ;; in de subcase ?
                 (:published-at        :datetime ,(s-prefix "pub:publicatieOp")) ;; in de subcase ?                per drukproef/publicatie ??     per drukproef/publicatie ??


### PR DESCRIPTION
# ✏️ KAS-2069: change publication-number type to number

In deze PR hebben we het type van een publicatie-nummer aangepast naar het type number om ervoor te zorgen dat we een automatische ophoging kunnen doen van de getallen.

