### PR TITLE
Feature/val 246 vlaamse veerkracht

### DIFF
--- a/config/migrations/20210119094000-annex-minister-council-type.graph
+++ b/config/migrations/20210119094000-annex-minister-council-type.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20210119094000-annex-minister-council-type.ttl
+++ b/config/migrations/20210119094000-annex-minister-council-type.ttl
@@ -1,0 +1,13 @@
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix kind: <http://kanselarij.vo.data.gift/id/concept/ministerraad-type-codes/> .
+
+kind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce a ext:MinisterraadType ;
+    mu:uuid "d36138a9-07f0-4df6-bbf0-abd51a24e4ce" ;
+    skos:prefLabel "Annex" .
+
+kind:1d16cb70-0ae9-489e-bf97-c74897222e3c a ext:MinisterraadType ;
+    mu:uuid "1d16cb70-0ae9-489e-bf97-c74897222e3c" ;
+    skos:prefLabel "Annex Vlaamse Veerkracht" ;
+    skos:broader kind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce .

--- a/config/migrations/20210119094000-annex-minister-council-type.ttl
+++ b/config/migrations/20210119094000-annex-minister-council-type.ttl
@@ -9,5 +9,5 @@ kind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce a ext:MinisterraadType ;
 
 kind:1d16cb70-0ae9-489e-bf97-c74897222e3c a ext:MinisterraadType ;
     mu:uuid "1d16cb70-0ae9-489e-bf97-c74897222e3c" ;
-    skos:prefLabel "Plan Vlaamse Veerkracht" ;
+    skos:prefLabel "Ministerraad - Plan Vlaamse Veerkracht" ;
     skos:broader kind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce .

--- a/config/migrations/20210119094000-annex-minister-council-type.ttl
+++ b/config/migrations/20210119094000-annex-minister-council-type.ttl
@@ -9,5 +9,5 @@ kind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce a ext:MinisterraadType ;
 
 kind:1d16cb70-0ae9-489e-bf97-c74897222e3c a ext:MinisterraadType ;
     mu:uuid "1d16cb70-0ae9-489e-bf97-c74897222e3c" ;
-    skos:prefLabel "Annex Vlaamse Veerkracht" ;
+    skos:prefLabel "Plan Vlaamse Veerkracht" ;
     skos:broader kind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce .

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -194,7 +194,9 @@
               ;; (piece                    :via ,(s-prefix "dossier:genereert") ;; this relation exists in legacy data, but we do not show this in the frontend currently
               ;;                           :as "notes") ;; note: is this a hasOne or hasMany ?
              (mail-campaign             :via      ,(s-prefix "ext:heeftMailCampagnes")
-                                        :as "mail-campaign"))
+                                        :as "mail-campaign")
+             (meeting                   :via      ,(s-prefix "dct:isPartOf")
+                                        :as "main-meeting"))
   :resource-base (s-url "http://kanselarij.vo.data.gift/id/zittingen/")
   :features '(include-uri)
   :on-path "meetings")


### PR DESCRIPTION
In kader van extra agenda voor Vlaamse Veerkracht:
- toevoegen van nieuw type vergaderactiviteit: 'Ministerraad Plan Vlaamse Veerkracht' (met parent 'Annex')
- toevoegen van link van Annex vergaderactiviteit naar reguliere vergaderactiviteit