### PR TITLE
Feature/VAL-197 search with tika

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -5,12 +5,39 @@
   "update_wait_interval_minutes": 8,
   "automatic_index_updates": true,
   "eager_indexing_groups": [
-    [{"variables":[], "name":"clean"}, {"variables":[], "name":"o-admin-on-public"}, {"variables":["admin"], "name":"o-admin-roles"}, {"variables":["kanselarij"], "name":"o-kanselarij-all"}, {"variables":[], "name":"public"}],
-    [{"variables":[], "name":"clean"}, {"variables":["kanselarij"], "name":"o-kanselarij-all"}, {"variables":[], "name":"o-kanselarij-on-public"}, {"variables":[], "name":"public"}],
-    [{"variables":[], "name":"clean"}, {"variables":["intern-regering"], "name":"o-intern-regering-read"}, {"variables":[], "name":"public"}],
-    [{"variables":[], "name":"clean"}, {"variables":["intern-overheid"], "name":"o-intern-overheid-read"}, {"variables":[], "name":"public"}],
-    [{"variables":[], "name":"clean"}, {"variables":["kanselarij"], "name":"ovrb"}, {"variables":[], "name":"public"}],
-    [{"variables":[], "name":"clean"}, {"variables":["minister"], "name":"o-minister-read"}, {"variables":[], "name":"public"}]
+    [
+      { "name": "o-admin-roles", "variables": ["admin"] },
+      { "name": "o-kanselarij-all", "variables": ["kanselarij"] },
+      { "name": "o-admin-on-public", "variables": [] },
+      { "name": "public", "variables": [] },
+      { "name": "clean", "variables": [] }
+    ],
+    [
+      { "name": "o-kanselarij-all", "variables": ["kanselarij"] },
+      { "name": "o-kanselarij-on-public", "variables": [] },
+      { "name": "public", "variables": [] },
+      { "name": "clean", "variables": [] }
+    ],
+    [
+      { "name": "o-intern-regering-read", "variables": ["intern-regering"] },
+      { "name": "public", "variables": [] },
+      { "name": "clean", "variables": [] }
+    ],
+    [
+      { "name": "o-intern-overheid-read", "variables": ["intern-overheid"] },
+      { "name": "public", "variables": [] },
+      { "name": "clean", "variables": [] }
+    ],
+    [
+      { "name": "ovrb", "variables": ["kanselarij"] },
+      { "name": "public", "variables": [] },
+      { "name": "clean", "variables": [] }
+    ],
+    [
+      { "name": "o-minister-read", "variables": ["minister"] },
+      { "name": "public", "variables": [] },
+      { "name": "clean", "variables": [] }
+    ]
   ],
   "attachments_path_base": "/data/",
   "eager_indexing_sparql_query": false,

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -186,13 +186,7 @@
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"
           },
-          "attachment.content": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer",
-            "term_vector": "with_positions_offsets_payloads"
-          },
-          "data.attachment.content": {
+          "data.content": {
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer",
@@ -267,7 +261,6 @@
           "http://data.vlaanderen.be/ns/besluitvorming#agendaStatus",
           "http://www.w3.org/2004/02/skos/core#prefLabel"
         ],
-        
         "subcaseTitle": [
           "https://data.vlaanderen.be/ns/dossier#doorloopt",
           "http://purl.org/dc/terms/title"
@@ -276,10 +269,20 @@
           "https://data.vlaanderen.be/ns/dossier#doorloopt",
           "http://purl.org/dc/terms/alternative"
         ],
-        "data": {
+        "documents": {
           "via": [
             "https://data.vlaanderen.be/ns/dossier#doorloopt",
             "http://mu.semte.ch/vocabularies/ext/bevatDocumentversie",
+            "http://mu.semte.ch/vocabularies/ext/file",
+            "^http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource"
+          ],
+          "attachment_pipeline": "attachment"
+        },
+        "decision": {
+          "via": [
+            "https://data.vlaanderen.be/ns/dossier#doorloopt",
+            "^http://mu.semte.ch/vocabularies/ext/beslissingVindtPlaatsTijdens",
+            "http://data.vlaanderen.be/ns/besluitvorming#genereertVerslag",
             "http://mu.semte.ch/vocabularies/ext/file",
             "^http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource"
           ],
@@ -355,106 +358,13 @@
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"
           },
-          "attachment.content": {
+          "documents.content": {
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer",
             "term_vector": "with_positions_offsets_payloads"
           },
-          "data.attachment.content": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer",
-            "term_vector": "with_positions_offsets_payloads"
-          }
-        }
-      }
-    },
-    {
-      "type": "caseByDecisionText",
-      "on_path": "casesByDecisionText",
-      "rdf_type": "https://data.vlaanderen.be/ns/dossier#Dossier",
-      "properties": {
-        "title": "http://purl.org/dc/terms/title",
-        "created": "http://purl.org/dc/terms/created",
-        "shortTitle": "http://purl.org/dc/terms/alternative",
-        "mandatees": [
-          "https://data.vlaanderen.be/ns/dossier#doorloopt",
-          "http://mu.semte.ch/vocabularies/ext/heeftBevoegde",
-          "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
-          "http://xmlns.com/foaf/0.1/name"
-        ],
-        "mandateeFirstNames": [
-          "https://data.vlaanderen.be/ns/dossier#doorloopt",
-          "http://mu.semte.ch/vocabularies/ext/heeftBevoegde",
-          "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
-          "http://xmlns.com/foaf/0.1/firstName"
-        ],
-        "mandateeFamilyNames": [
-          "https://data.vlaanderen.be/ns/dossier#doorloopt",
-          "http://mu.semte.ch/vocabularies/ext/heeftBevoegde",
-          "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
-          "http://xmlns.com/foaf/0.1/familyName"
-        ],
-        "sessionDates": [
-          "https://data.vlaanderen.be/ns/dossier#doorloopt",
-          "^http://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens",
-          "http://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt",
-          "^http://purl.org/dc/terms/hasPart",
-          "http://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
-          "http://data.vlaanderen.be/ns/besluit#geplandeStart"
-        ],
-        "data": {
-          "via": [
-            "https://data.vlaanderen.be/ns/dossier#doorloopt",
-            "^http://mu.semte.ch/vocabularies/ext/beslissingVindtPlaatsTijdens",
-            "http://data.vlaanderen.be/ns/besluitvorming#genereertVerslag",
-            "http://mu.semte.ch/vocabularies/ext/file",
-            "^http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource"
-          ],
-          "attachment_pipeline": "attachment"
-        }
-      },
-      "mappings": {
-        "properties": {
-          "title": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer"
-          },
-          "created": {
-            "type": "date"
-          },
-          "shortTitle": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer"
-          },
-          "mandatees": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer"
-          },
-          "mandateeFirstNames": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer"
-          },
-          "mandateeFamilyNames": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer"
-          },
-          "sessionDates": {
-            "type": "date"
-          },
-          "attachment.content": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer",
-            "term_vector": "with_positions_offsets_payloads"
-          },
-          "data.attachment.content": {
+          "decision.content": {
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer",

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -248,8 +248,7 @@
         ],
         "documents": {
           "via": [
-            "https://data.vlaanderen.be/ns/dossier#doorloopt",
-            "http://mu.semte.ch/vocabularies/ext/bevatDocumentversie",
+            "https://data.vlaanderen.be/ns/dossier#Dossier.bestaatUit",
             "http://mu.semte.ch/vocabularies/ext/file",
             "^http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource"
           ],

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -329,7 +329,7 @@
             "search_analyzer": "dutchanalyzer",
             "term_vector": "with_positions_offsets_payloads"
           },
-          "decision.content": {
+          "decisions.content": {
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer",

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -207,10 +207,6 @@
           "^https://data.vlaanderen.be/ns/dossier#behandelt",
           "http://mu.semte.ch/vocabularies/ext/publicatie/publicatieNummer"
         ],
-        "publicationFlowNumac": [
-          "^https://data.vlaanderen.be/ns/dossier#behandelt",
-          "http://mu.semte.ch/vocabularies/ext/publicatie/numacNummer"
-        ],
         "publicationFlowRemark": [
           "^https://data.vlaanderen.be/ns/dossier#behandelt",
           "http://mu.semte.ch/vocabularies/ext/publicatie/publicatieOpmerking"
@@ -240,22 +236,6 @@
           "^http://purl.org/dc/terms/hasPart",
           "http://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
           "http://data.vlaanderen.be/ns/besluit#geplandeStart"
-        ],
-        "meetingId": [
-          "https://data.vlaanderen.be/ns/dossier#doorloopt",
-          "^http://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens",
-          "http://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt",
-          "^http://purl.org/dc/terms/hasPart",
-          "http://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
-          "http://mu.semte.ch/vocabularies/core/uuid"
-        ],
-        "agendaStatus": [
-          "https://data.vlaanderen.be/ns/dossier#doorloopt",
-          "^http://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens",
-          "http://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt",
-          "^http://purl.org/dc/terms/hasPart",
-          "http://data.vlaanderen.be/ns/besluitvorming#agendaStatus",
-          "http://www.w3.org/2004/02/skos/core#prefLabel"
         ],
         "subcaseTitle": [
           "https://data.vlaanderen.be/ns/dossier#doorloopt",
@@ -310,11 +290,6 @@
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"
           },
-          "publicationFlowNumac": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer"
-          },
           "publicationFlowRemark": {
             "type": "text",
             "analyzer": "dutchanalyzer",
@@ -337,12 +312,6 @@
           },
           "sessionDates": {
             "type": "date"
-          },
-          "meetingId": {
-            "type": "keyword"
-          },
-          "agendaStatus": {
-            "type": "keyword"
           },
           "subcaseTitle": {
             "type": "text",

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -274,7 +274,7 @@
           ],
           "attachment_pipeline": "attachment"
         },
-        "decision": {
+        "decisions": {
           "via": [
             "https://data.vlaanderen.be/ns/dossier#doorloopt",
             "^http://mu.semte.ch/vocabularies/ext/beslissingVindtPlaatsTijdens",

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -199,6 +199,7 @@
         "title": "http://purl.org/dc/terms/title",
         "created": "http://purl.org/dc/terms/created",
         "shortTitle": "http://purl.org/dc/terms/alternative",
+        "isArchived": "http://mu.semte.ch/vocabularies/ext/isGearchiveerd",
         "publicationFlowId": [
           "^https://data.vlaanderen.be/ns/dossier#behandelt",
           "http://mu.semte.ch/vocabularies/core/uuid"
@@ -279,6 +280,9 @@
           },
           "created": {
             "type": "date"
+          },
+          "isArchived": {
+            "type": "boolean"
           },
           "shortTitle": {
             "type": "text",

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -86,27 +86,14 @@
           "^http://www.w3.org/ns/prov#wasRevisionOf",
           "http://mu.semte.ch/vocabularies/core/uuid"
         ],
-        "agendaTitle": [
-          "^http://purl.org/dc/terms/hasPart",
-          "http://purl.org/dc/terms/title"
-        ],
         "agendaSerialNumber": [
           "^http://purl.org/dc/terms/hasPart",
           "http://data.vlaanderen.be/ns/besluitvorming#volgnummer"
-        ],
-        "agendaStatus": [
-          "^http://purl.org/dc/terms/hasPart",
-          "http://data.vlaanderen.be/ns/besluitvorming#agendaStatus"
         ],
         "meetingId": [
           "^http://purl.org/dc/terms/hasPart",
           "http://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
           "http://mu.semte.ch/vocabularies/core/uuid"
-        ],
-        "meetingAgendaClosed": [
-          "^http://purl.org/dc/terms/hasPart",
-          "http://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
-          "http://mu.semte.ch/vocabularies/ext/finaleZittingVersie"
         ],
         "sessionDates": [
           "^http://purl.org/dc/terms/hasPart",
@@ -127,10 +114,6 @@
           "http://mu.semte.ch/vocabularies/ext/heeftBevoegdeVoorAgendapunt",
           "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
           "http://xmlns.com/foaf/0.1/familyName"
-        ],
-        "theme": [
-          "http://mu.semte.ch/vocabularies/ext/agendapuntSubject",
-          "http://www.w3.org/2004/02/skos/core#prefLabel"
         ],
         "data": {
           "via": [
@@ -175,20 +158,11 @@
           "nextVersionId": {
             "type": "keyword"
           },
-          "agendaTitle": {
-            "type": "text"
-          },
           "agendaSerialNumber": {
-            "type": "keyword"
-          },
-          "agendaStatus": {
             "type": "keyword"
           },
           "meetingId": {
             "type": "keyword"
-          },
-          "meetingAgendaClosed": {
-            "type": "boolean"
           },
           "sessionDates": {
             "type": "date"
@@ -204,11 +178,6 @@
             "search_analyzer": "dutchanalyzer"
           },
           "mandateeFamilyNames": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer"
-          },
-          "theme": {
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -39,6 +39,8 @@ services:
       JRUBY_OPTIONS: ""
   elasticsearch:
     restart: "no"
+  tika:
+    restart: "no"
   database-healthcheck:
     restart: "no"
   # kibana:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     logging: *default-logging
     restart: always
   musearch:
-   image: semtech/mu-search:0.8.0-beta.1
+   image: semtech/mu-search:0.8.0-beta.2
    volumes:
       - ./config/search:/config
       - ./data/files:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,10 +58,11 @@ services:
     logging: *default-logging
     restart: always
   musearch:
-   image: semtech/mu-search:0.7.0
+   image: semtech/mu-search:0.8.0-beta.1
    volumes:
       - ./config/search:/config
       - ./data/files:/data
+      - ./data/tika/cache:/cache
    environment:
      NUMBER_OF_THREADS: 16
      JRUBY_OPTIONS: "-J-Xmx32g" # overwrite for development
@@ -71,10 +72,13 @@ services:
   elasticsearch:
     image: semtech/mu-search-elastic-backend:1.0.0
     environment:
-      - cluster.initial_master_nodes=elasticsearch
-      - node.name=elasticsearch
+      discovery.type: "single-node"
     volumes:
       - ./data/elasticsearch/:/usr/share/elasticsearch/data
+    logging: *default-logging
+    restart: always
+  tika:
+    image: apache/tika:1.24-full
     logging: *default-logging
     restart: always
   deltanotifier:


### PR DESCRIPTION
New release includes:
- usage of Tika to cache extracted content from documents. This will improve performance of (re)indexing of the same documents
- support for multiple fields with an attachment pipeline in one index

Due to the support for multiple attachment pipeline fields in one index the case and caseByDecisionText indexes can be merged into one index.

Because the index configuration changed, this PR requires a full reindex when deployed on the server.