### PR TITLE
KAS-2194 bump agenda-approve-service for test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,7 @@ services:
     labels:
       - "logging=true"
   agenda-approve-service:
-    image: kanselarij/agenda-approve-service:3.1.0
+    image: kanselarij/agenda-approve-service:3.2.0
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
todo, tag 3.2.0 is gemaakt van branch.
Deze pr moet niet perse gemerged worden, had deze nodig voor custom branch builder op jenkins
Na mergen in master vanaf master 3.2.1 maken (tenzij er geen changes gebeurt zijn op master, voor de zekerheid toch doen kan geen kwaad)

agenda-approve-service https://github.com/kanselarij-vlaanderen/agenda-approve-service/pull/19
frontend: https://github.com/kanselarij-vlaanderen/kaleidos-frontend/pull/695