### PR TITLE
Feature/val 278 email delivery service

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -82,7 +82,7 @@ defmodule Acl.UserGroups.Config do
   defp email_resource_types() do
     [
       # "http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#Mailbox",
-      "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder",
+      # "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder",
       "http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#Email",
       # "http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#MessageHeader",
     ]
@@ -271,8 +271,13 @@ defmodule Acl.UserGroups.Config do
                 static_unconfidential_code_list_types() ++
                 user_account_resource_types() ++
                 file_bundling_resource_types() ++
-                publication_resource_types() ++
-                email_resource_types()
+                publication_resource_types()
+            }
+          },
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/system/email",
+            constraint: %ResourceConstraint{
+              resource_types: email_resource_types()
             }
           },
         ]
@@ -287,8 +292,7 @@ defmodule Acl.UserGroups.Config do
             constraint: %ResourceConstraint{
               resource_types: publication_resource_types() ++
                 generic_besluitvorming_resource_types() ++
-                document_resource_types() ++
-                email_resource_types()
+                document_resource_types()
             }
           },
           %GraphSpec{
@@ -297,7 +301,7 @@ defmodule Acl.UserGroups.Config do
               resource_types: email_resource_types()
             }
           },
-      ]
+        ]
       },
 
       # // CLEANUP

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -258,8 +258,7 @@ defmodule Acl.UserGroups.Config do
         name: "o-kanselarij-all",
         useage: [:read, :write, :read_for_write],
         access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/admin
-                                 <http://data.kanselarij.vlaanderen.be/id/group/kanselarij>
-                                 <http://data.kanselarij.vlaanderen.be/id/group/minister president> "),
+                                 <http://data.kanselarij.vlaanderen.be/id/group/kanselarij>"),
         graphs: [
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/organizations/kanselarij",

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -10,23 +10,16 @@ alias Acl.GroupSpec.GraphCleanup, as: GraphCleanup
 
 defmodule Acl.UserGroups.Config do
 
-  defp named_graph_access_by_role( group_string, graph_name ) do
+  defp access_by_role( group_uris ) do
     %AccessByQuery{
-      vars: ["name"],
-      query: named_sparql_query_for_access_role( group_string, graph_name ) }
-  end
-
-  defp named_sparql_query_for_access_role( group_string, graph_name ) do
-    "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-    PREFIX session: <http://mu.semte.ch/vocabularies/session/>
-    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-    SELECT ?name ?session_role WHERE {
-      BIND(\"#{graph_name}\" AS ?name)
-      <SESSION_ID> session:account / ^foaf:account / ^foaf:member ?group .
-      BIND( STRAFTER(STR(?group), \"http://data.kanselarij.vlaanderen.be/id/group/\") AS ?session_role )
-      FILTER(?session_role IN (\"#{group_string}\") )
-    } LIMIT 1"
+      vars: [],
+      query: "PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+              PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+              SELECT ?group_uri WHERE {
+                <SESSION_ID> session:account / ^foaf:account / ^foaf:member ?group_uri .
+                VALUES ?group_uri { #{group_uris} }
+              } LIMIT 1"
+    }
   end
 
   defp direct_write_on_public( group_string ) do
@@ -179,10 +172,10 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-intern-overheid-read",
         useage: [:read, :write, :read_for_write],
-        access: named_graph_access_by_role( "overheid", "intern-overheid" ),
+        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/overheid>" ),
         graphs: [
           %GraphSpec{
-            graph: "http://mu.semte.ch/graphs/organizations/",
+            graph: "http://mu.semte.ch/graphs/organizations/intern-overheid",
             constraint: %ResourceConstraint{
               resource_types: ["http://mu.semte.ch/vocabularies/ext/NotAThing"] ++file_bundling_resource_types()
             }
@@ -225,10 +218,10 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-admin-roles",
         useage: [:read, :write, :read_for_write],
-        access: named_graph_access_by_role( "admin", "admin" ),
+        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/admin>" ),
         graphs: [
           %GraphSpec{
-            graph: "http://mu.semte.ch/graphs/organizations/",
+            graph: "http://mu.semte.ch/graphs/organizations/admin",
             constraint: %ResourceConstraint{
               resource_types: ["http://mu.semte.ch/vocabularies/ext/NotAThing"]
             }
@@ -238,10 +231,10 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-intern-regering-read",
         useage: [:read, :write, :read_for_write],
-        access: named_graph_access_by_role( "kabinet", "intern-regering" ),
+        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/kabinet>" ),
         graphs: [
           %GraphSpec{
-            graph: "http://mu.semte.ch/graphs/organizations/",
+            graph: "http://mu.semte.ch/graphs/organizations/intern-regering",
             constraint: %ResourceConstraint{
               resource_types: ["http://mu.semte.ch/vocabularies/ext/NotAThing"] ++file_bundling_resource_types()
             }
@@ -251,10 +244,10 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-minister-read",
         useage: [:read, :write, :read_for_write],
-        access: named_graph_access_by_role( "minister", "minister" ),
+        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/minister>" ),
         graphs: [
           %GraphSpec{
-            graph: "http://mu.semte.ch/graphs/organizations/",
+            graph: "http://mu.semte.ch/graphs/organizations/minister",
             constraint: %ResourceConstraint{
               resource_types: ["http://mu.semte.ch/vocabularies/ext/NotAThing"] ++file_bundling_resource_types()
             }
@@ -264,10 +257,12 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-kanselarij-all",
         useage: [:read, :write, :read_for_write],
-        access: named_graph_access_by_role( "kanselarij\", \"minister president\", \"admin", "kanselarij" ),
+        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/admin
+                                 <http://data.kanselarij.vlaanderen.be/id/group/kanselarij>
+                                 <http://data.kanselarij.vlaanderen.be/id/group/minister president> "),
         graphs: [
           %GraphSpec{
-            graph: "http://mu.semte.ch/graphs/organizations/",
+            graph: "http://mu.semte.ch/graphs/organizations/kanselarij",
             constraint: %ResourceConstraint{
               resource_types: newsletter_resource_types() ++
                 agendering_resource_types() ++
@@ -286,10 +281,10 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "ovrb",
         useage: [:read, :write, :read_for_write],
-        access: named_graph_access_by_role( "OVRB", "kanselarij" ), # TODO: Read access on whole "kanselarij"-graph for now. Recent kanselarij-data will have separate graph later on
+        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/OVRB>" ), # TODO: Read access on whole "kanselarij"-graph for now. Recent kanselarij-data will have separate graph later on
         graphs: [
           %GraphSpec{
-            graph: "http://mu.semte.ch/graphs/organizations/",
+            graph: "http://mu.semte.ch/graphs/organizations/kanselarij",
             constraint: %ResourceConstraint{
               resource_types: publication_resource_types() ++
                 generic_besluitvorming_resource_types() ++
@@ -297,7 +292,13 @@ defmodule Acl.UserGroups.Config do
                 email_resource_types()
             }
           },
-        ]
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/system/email",
+            constraint: %ResourceConstraint{
+              resource_types: email_resource_types()
+            }
+          },
+      ]
       },
 
       # // CLEANUP

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -259,7 +259,7 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-kanselarij-all",
         useage: [:read, :write, :read_for_write],
-        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/admin
+        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/admin>
                                  <http://data.kanselarij.vlaanderen.be/id/group/kanselarij>"),
         graphs: [
           %GraphSpec{

--- a/config/migrations/20210219130600-mailbox-and-folders.sparql
+++ b/config/migrations/20210219130600-mailbox-and-folders.sparql
@@ -1,0 +1,42 @@
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/system/email> {
+    <http://themis.vlaanderen.be/id/mailboxes/e8364a49-2696-48cc-aef1-e1e396a0cd34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#Mailbox>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "e8364a49-2696-48cc-aef1-e1e396a0cd34" ;
+    <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://themis.vlaanderen.be/id/mail-folders/fe95fca6-f4a1-45e8-87b1-73925cf32f03> ;
+    <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://themis.vlaanderen.be/id/mail-folders/4296e6af-7d4f-423d-ba89-ed4cbbb33ae7> ;
+    <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://themis.vlaanderen.be/id/mail-folders/9a8c2a5d-719e-43f1-97c9-06cf3dc33b4a> ;
+    <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://themis.vlaanderen.be/id/mail-folders/d5fc2c24-eafc-4c84-8400-120a1d9f83a0> ;
+    <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://themis.vlaanderen.be/id/mail-folders/359965f6-c24e-4de0-b0ae-b658cf66587b> ;
+    <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://themis.vlaanderen.be/id/mail-folders/3b9836fa-806a-413e-9492-889ac00cc412> .
+
+    <http://themis.vlaanderen.be/id/mail-folders/fe95fca6-f4a1-45e8-87b1-73925cf32f03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "fe95fca6-f4a1-45e8-87b1-73925cf32f03";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "inbox";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Incoming mails".
+
+    <http://themis.vlaanderen.be/id/mail-folders/4296e6af-7d4f-423d-ba89-ed4cbbb33ae7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "4296e6af-7d4f-423d-ba89-ed4cbbb33ae7";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "outbox";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Mails to be sent".
+
+    <http://themis.vlaanderen.be/id/mail-folders/9a8c2a5d-719e-43f1-97c9-06cf3dc33b4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "9a8c2a5d-719e-43f1-97c9-06cf3dc33b4a";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "sentbox";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Sent mails".
+
+    <http://themis.vlaanderen.be/id/mail-folders/d5fc2c24-eafc-4c84-8400-120a1d9f83a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "d5fc2c24-eafc-4c84-8400-120a1d9f83a0";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "sending";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Mails currently being processed for sending".
+
+    <http://themis.vlaanderen.be/id/mail-folders/359965f6-c24e-4de0-b0ae-b658cf66587b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "359965f6-c24e-4de0-b0ae-b658cf66587b";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "drafts";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Draft emails".
+
+    <http://themis.vlaanderen.be/id/mail-folders/3b9836fa-806a-413e-9492-889ac00cc412> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "3b9836fa-806a-413e-9492-889ac00cc412";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "failbox";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Mails failed to be sent".
+  }
+}

--- a/config/resources/email-domain.lisp
+++ b/config/resources/email-domain.lisp
@@ -11,7 +11,8 @@
   :class (s-prefix "nfo:Folder")
   :properties `((:name :string ,(s-prefix "nie:title"))
                 (:description :string ,(s-prefix "nie:description")))
-  :has-many `((email :via ,(s-prefix "email:hasEmail");;hack, as mu-cl-resources doesn't support superclasses yet (http://oscaf.sourceforge.net/nmo.html#nmo:MailboxDataObject)
+  :has-many `((email :via ,(s-prefix "nmo:isPartOf") ;; TODO: nie:isPartOf isn't valid part of NEPOMUK
+                    :inverse t
                     :as "emails")
              (folder :via ,(s-prefix "email:hasFolder");;hack, as mu-cl-resources doesn't support superclasses yet (http://oscaf.sourceforge.net/nmo.html#nmo:MailboxDataObject)
                     :as "folders"))
@@ -35,8 +36,7 @@
                 (:sent-date :datetime ,(s-prefix "nmo:sentDate")))
   :has-one `((email :via ,(s-prefix "nmo:inReplyTo")
                     :as "in-reply-to")
-             (folder :via ,(s-prefix "nmo:isPartOf")
-                    :inverse t
+             (folder :via ,(s-prefix "nmo:isPartOf") ;; TODO: nie:isPartOf isn't valid part of NEPOMUK
                     :as "folder"))
   :has-many `(
   ;           (email-header :via ,(s-prefix "nmo:messageHeader")

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -97,3 +97,5 @@ services:
     restart: "no"
   document-versions-service:
     restart: "no"
+  mail-delivery:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -269,4 +269,16 @@ services:
     restart: always
     labels:
       - "logging=true"
-
+  mail-delivery:
+    image: redpencil/deliver-email-service:0.1.3
+    environment:
+      MAILBOX_URI: "http://themis.vlaanderen.be/id/mailboxes/e8364a49-2696-48cc-aef1-e1e396a0cd34"
+      WELL_KNOWN_SERVICE: "test"
+      EMAIL_ADDRESS: "noreply@kaleidos.vlaanderen.be"
+      EMAIL_CRON_PATTERN: "*/5 * * * *"
+    volumes:
+      - ./data/files:/share
+    logging: *default-logging
+    restart: always
+    labels:
+      - "logging=true"


### PR DESCRIPTION
Mail delivery service to send mails found in the outbox each 5 minutes.

By default the service is configured in 'test' mode which will fake email sending using [Ethereal mail](https://ethereal.email/).

On test/production environments the following service configuration needs to be put in docker-compose.override.yml
```yaml
  mail-delivery:
    environment:
      WELL_KNOWN_SERVICE: "Outlook365"
      EMAIL_PASSWORD: "password-of-the-mail-account"
```

Example SPARQL query to schedule an email for delivery:
```sparql
PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

INSERT DATA {
  GRAPH <http://mu.semte.ch/graphs/system/email> {
    <http://themis.vlaanderen.be/id/emails/1c729bc4-3a60-4ac7-9836-cb65b2c5b55e> a nmo:Email;
        mu:uuid "1c729bc4-3a60-4ac7-9836-cb65b2c5b55e" ;
        nmo:messageFrom "noreply@kaleidos.vlaanderen.be";
        nmo:emailTo "john.doe@example.com";
        nmo:emailBcc "john.doe@example.com";
        nmo:messageSubject "Test mail vanuit de Kaleidos mailbox";
        nmo:htmlMessageContent """<html><body><p>Hallo,<br></p><p>dit is een test e-mail om e-mails te kunnen sturen vanuit de <a href="https://kaleidos.vlaanderen.be">Kaleidos</a> applicatie.</p><br><p>Groeten,<br>redpencil.io<br></p></body></html> """;
        nmo:sentDate "20210219T11:40:00.000Z";
        nmo:isPartOf <http://themis.vlaanderen.be/id/mail-folders/4296e6af-7d4f-423d-ba89-ed4cbbb33ae7> ;
        nmo:hasAttachment <http://mu.semte.ch/services/file-service/files/602fa6c6424d81000d000002> ;
        nmo:hasAttachment <http://mu.semte.ch/services/file-service/files/602fa6c6424d81000d000000> .
  }
}
```