### PR TITLE
KAS-2366: themis uris

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -41,7 +41,7 @@ defmodule Acl.UserGroups.Config do
       "http://www.w3.org/ns/prov#Activity",
     ]
   end
-  
+
   defp document_resource_types() do
     [
       "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
@@ -59,9 +59,10 @@ defmodule Acl.UserGroups.Config do
       "http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt",
       "http://data.vlaanderen.be/ns/besluit#Vergaderactiviteit",
       "http://data.vlaanderen.be/ns/besluitvorming#Agendering",
+      "http://mu.semte.ch/vocabularies/ext/Indieningsactiviteit"
     ]
   end
-  
+
   defp file_bundling_resource_types() do
     [
       "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
@@ -95,7 +96,7 @@ defmodule Acl.UserGroups.Config do
       "http://data.vlaanderen.be/ns/besluitvorming#NieuwsbriefInfo",
     ]
   end
-  
+
   defp user_account_resource_types() do
     [
       "http://xmlns.com/foaf/0.1/OnlineAccount",
@@ -105,7 +106,7 @@ defmodule Acl.UserGroups.Config do
     ]
   end
 
-  # Also insert your type as ext:PublicClass 
+  # Also insert your type as ext:PublicClass
   defp unconfidential_resource_types() do
     [
       "http://mu.semte.ch/vocabularies/ext/Goedkeuring",
@@ -120,9 +121,9 @@ defmodule Acl.UserGroups.Config do
       "http://www.w3.org/ns/org#Organization",
     ]
   end
-  # Also insert your type as ext:PublicClass 
+  # Also insert your type as ext:PublicClass
 
-  # Also insert your type as ext:PublicClass 
+  # Also insert your type as ext:PublicClass
   defp static_unconfidential_code_list_types() do
     [
       "http://mu.semte.ch/vocabularies/ext/DocumentTypeCode",
@@ -143,7 +144,7 @@ defmodule Acl.UserGroups.Config do
       "http://publications.europa.eu/ontology/euvoc#Language",
     ]
   end
-  # Also insert your type as ext:PublicClass 
+  # Also insert your type as ext:PublicClass
 
   def user_groups do
     # These elements are walked from top to bottom.  Each of them may

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -109,7 +109,7 @@ export default [
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://mu.semte.ch/vocabularies/ext/bevatDocumentversie' // Will get changed in future model refactoring
+        value: 'http://www.w3.org/ns/prov#generated'
       }
     },
     callback: {

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -136,6 +136,9 @@ defmodule Dispatcher do
   match "/agenda-activities/*path", @any do
     Proxy.forward conn, path, "http://cache/agenda-activities/"
   end
+  match "/submission-activities/*path", @any do
+    Proxy.forward conn, path, "http://cache/submission-activities/"
+  end
   match "/access-levels/*path", @any do
     Proxy.forward conn, path, "http://cache/access-levels/"
   end

--- a/config/resources/alerts-domain.lisp
+++ b/config/resources/alerts-domain.lisp
@@ -6,7 +6,7 @@
 								(:message 		:string 	,(s-prefix "ext:bericht")))
   :has-one `((alert-type 			:via 			,(s-prefix "ext:type") ;; NOTE: What is the domain of Besluit geeftAanleidingTot? guessed prov:generated
                          			:as "type"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/systeem-notificaties/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/systeem-notificaties/")
   :features '(include-uri)
   :on-path "alerts")
 
@@ -15,7 +15,7 @@
   :properties `((:label 			:string 	,(s-prefix "skos:prefLabel"))
                 (:scope-note 	:string 	,(s-prefix "skos:scopeNote"))
                 (:alt-label :string ,(s-prefix "skos:altLabel")))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/systeem-notificatie-types/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/systeem-notificatie-types/")
   :features '(include-uri)
   :on-path "alert-types")
 
@@ -26,6 +26,6 @@
                 (:alt-label   :string   ,(s-prefix "skos:altLabel"))
                 (:description :string   ,(s-prefix "ext:beschrijving"))
                 (:type        :string   ,(s-prefix "ext:type"))) ;; Type "agenda","minutes","decisions"...
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/snelkoppelingen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/snelkoppelingen/")
   :features '(include-uri)
   :on-path "shortcuts")

--- a/config/resources/alerts-domain.lisp
+++ b/config/resources/alerts-domain.lisp
@@ -6,7 +6,7 @@
 								(:message 		:string 	,(s-prefix "ext:bericht")))
   :has-one `((alert-type 			:via 			,(s-prefix "ext:type") ;; NOTE: What is the domain of Besluit geeftAanleidingTot? guessed prov:generated
                          			:as "type"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/systeem-notificaties/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/systeemnotificatie/")
   :features '(include-uri)
   :on-path "alerts")
 
@@ -15,7 +15,7 @@
   :properties `((:label 			:string 	,(s-prefix "skos:prefLabel"))
                 (:scope-note 	:string 	,(s-prefix "skos:scopeNote"))
                 (:alt-label :string ,(s-prefix "skos:altLabel")))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/systeem-notificatie-types/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/systeemnotificatie-type/")
   :features '(include-uri)
   :on-path "alert-types")
 
@@ -26,6 +26,6 @@
                 (:alt-label   :string   ,(s-prefix "skos:altLabel"))
                 (:description :string   ,(s-prefix "ext:beschrijving"))
                 (:type        :string   ,(s-prefix "ext:type"))) ;; Type "agenda","minutes","decisions"...
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/snelkoppelingen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/snelkoppeling/")
   :features '(include-uri)
   :on-path "shortcuts")

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -19,7 +19,7 @@
                                :as "next-version"))
   :has-many `((agendaitem     :via        ,(s-prefix "dct:hasPart")
                               :as "agendaitems"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/agendas/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/agendas/")
   :features '(include-uri)
   :on-path "agendas")
 
@@ -31,7 +31,7 @@
   :has-many `((agenda     :via        ,(s-prefix "besluitvorming:agendaStatus")
                           :inverse t
                           :as "agendas"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/agendastatus/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/agendastatus/")
   :features '(include-uri)
   :on-path "agendastatuses")
 
@@ -79,7 +79,7 @@
                                       :as "pieces")
               (piece                  :via ,(s-prefix "ext:bevatReedsBezorgdAgendapuntDocumentversie") ;; NOTE: instead of dct:hasPart (mu-cl-resources relation type checking workaround)
                                       :as "linked-pieces"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/agendapunten/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/agendapunten/")
   :features `(no-pagination-defaults include-uri)
   :on-path "agendaitems")
 
@@ -93,7 +93,7 @@
              (agendaitem    :via ,(s-prefix "ext:agendapuntGoedkeuring")
                             :inverse t
                             :as "agendaitem"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/goedkeuringen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/goedkeuringen/")
   :on-path "approvals")
 
 (define-resource agenda-item-treatment ()
@@ -117,7 +117,7 @@
                                     :as "newsletter-info")
              (decision-result-code  :via        ,(s-prefix "besluitvorming:resultaat")
                                     :as "decision-result-code"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/behandelingen-van-agendapunt/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/behandelingen-van-agendapunt/")
   :features '(include-uri)
   :on-path "agenda-item-treatments")
 
@@ -127,7 +127,7 @@
                 (:label       :string ,(s-prefix "skos:prefLabel"))
                 (:priority    :number ,(s-prefix "ext:priority"))
                )
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/beslissings-resultaat-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/beslissings-resultaat-codes/")
   :features '(include-uri)
   :on-path "decision-result-codes")
 
@@ -138,7 +138,7 @@
                                    :as "area-of-jurisdiction")
              (government-unit-classification-code :via ,(s-prefix "besluit:classificatie")
                                                   :as "classification"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/bestuurseenheden/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/bestuurseenheden/")
   :features '(include-uri)
   :on-path "government-units")
 
@@ -150,7 +150,7 @@
   :has-many `((government-unit :via ,(s-prefix "besluit:werkingsgebied")
                                :inverse t
                                :as "government-units"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/werkingsgebieden/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/werkingsgebieden/")
   :features '(include-uri)
   :on-path "jurisdiction-areas")
 
@@ -160,7 +160,7 @@
   :properties `((:label :string ,(s-prefix "skos:prefLabel"))
                 (:scope-note :string ,(s-prefix "skos:scopeNote"))
                 (:alt-label :string ,(s-prefix "skos:altLabel")))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/bestuurseenheid-classificatie-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/bestuurseenheid-classificatie-codes/")
   :features '(include-uri)
   :on-path "government-unit-classification-codes")
 
@@ -197,6 +197,6 @@
                                         :as "mail-campaign")
              (meeting                   :via      ,(s-prefix "dct:isPartOf")
                                         :as "main-meeting"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/zittingen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/zittingen/")
   :features '(include-uri)
   :on-path "meetings")

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -19,7 +19,7 @@
                                :as "next-version"))
   :has-many `((agendaitem     :via        ,(s-prefix "dct:hasPart")
                               :as "agendaitems"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/agendas/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/agenda/")
   :features '(include-uri)
   :on-path "agendas")
 
@@ -31,7 +31,7 @@
   :has-many `((agenda     :via        ,(s-prefix "besluitvorming:agendaStatus")
                           :inverse t
                           :as "agendas"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/agendastatus/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/agenda-status/")
   :features '(include-uri)
   :on-path "agendastatuses")
 
@@ -79,7 +79,7 @@
                                       :as "pieces")
               (piece                  :via ,(s-prefix "ext:bevatReedsBezorgdAgendapuntDocumentversie") ;; NOTE: instead of dct:hasPart (mu-cl-resources relation type checking workaround)
                                       :as "linked-pieces"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/agendapunten/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/agendapunt/")
   :features `(no-pagination-defaults include-uri)
   :on-path "agendaitems")
 
@@ -93,7 +93,7 @@
              (agendaitem    :via ,(s-prefix "ext:agendapuntGoedkeuring")
                             :inverse t
                             :as "agendaitem"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/goedkeuringen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/goedkeuring/")
   :on-path "approvals")
 
 (define-resource agenda-item-treatment ()
@@ -117,7 +117,7 @@
                                     :as "newsletter-info")
              (decision-result-code  :via        ,(s-prefix "besluitvorming:resultaat")
                                     :as "decision-result-code"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/behandelingen-van-agendapunt/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/behandeling-van-agendapunt/")
   :features '(include-uri)
   :on-path "agenda-item-treatments")
 
@@ -127,7 +127,7 @@
                 (:label       :string ,(s-prefix "skos:prefLabel"))
                 (:priority    :number ,(s-prefix "ext:priority"))
                )
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/beslissings-resultaat-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/beslissingsresultaat-code/")
   :features '(include-uri)
   :on-path "decision-result-codes")
 
@@ -138,7 +138,7 @@
                                    :as "area-of-jurisdiction")
              (government-unit-classification-code :via ,(s-prefix "besluit:classificatie")
                                                   :as "classification"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/bestuurseenheden/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/bestuurseenheid/")
   :features '(include-uri)
   :on-path "government-units")
 
@@ -150,7 +150,7 @@
   :has-many `((government-unit :via ,(s-prefix "besluit:werkingsgebied")
                                :inverse t
                                :as "government-units"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/werkingsgebieden/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/werkingsgebied/")
   :features '(include-uri)
   :on-path "jurisdiction-areas")
 
@@ -160,7 +160,7 @@
   :properties `((:label :string ,(s-prefix "skos:prefLabel"))
                 (:scope-note :string ,(s-prefix "skos:scopeNote"))
                 (:alt-label :string ,(s-prefix "skos:altLabel")))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/bestuurseenheid-classificatie-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/bestuurseenheid-classificatie-code/")
   :features '(include-uri)
   :on-path "government-unit-classification-codes")
 
@@ -197,6 +197,6 @@
                                         :as "mail-campaign")
              (meeting                   :via      ,(s-prefix "dct:isPartOf")
                                         :as "main-meeting"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/zittingen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/zitting/")
   :features '(include-uri)
   :on-path "meetings")

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -37,9 +37,6 @@
             (piece                      :via      ,(s-prefix "pav:previousVersion")
                                         :inverse t
                                         :as "next-piece")
-            (subcase                    :via ,(s-prefix "ext:bevatDocumentversie") ;; should be hasMany, not used in frontend yet
-                                        :inverse t
-                                        :as "subcase")
             (subcase                    :via ,(s-prefix "ext:bevatReedsBezorgdeDocumentversie") ;; should be hasMany, not used in frontend yet
                                         :inverse t
                                         :as "linked-subcase")

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -9,7 +9,7 @@
                                         :inverse t
                                         :as "agenda-item-treatment")
                                         )
-  :resource-base (s-url "http://themis.vlaanderen.be/id/series/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/serie/")
   :features '(include-uri)
   :on-path "document-containers")
 
@@ -74,7 +74,7 @@
               (agendaitem               :via ,(s-prefix "besluitvorming:geagendeerdStuk")
                                         :inverse t
                                         :as "agendaitems"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/stukken/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/stuk/")
   :features `(include-uri)
   :on-path "pieces")
 
@@ -95,7 +95,7 @@
                                     :as "subtypes"))
   :has-one `((document-type         :via    ,(s-prefix "skos:broader")
                                     :as "supertype"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/document-type-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/document-type/")
   :features '(include-uri)
   :on-path "document-types")
 

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -9,7 +9,7 @@
                                         :inverse t
                                         :as "agenda-item-treatment")
                                         )
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/series/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/series/")
   :features '(include-uri)
   :on-path "document-containers")
 
@@ -74,7 +74,7 @@
               (agendaitem               :via ,(s-prefix "besluitvorming:geagendeerdStuk")
                                         :inverse t
                                         :as "agendaitems"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/stukken/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/stukken/")
   :features `(include-uri)
   :on-path "pieces")
 
@@ -95,7 +95,7 @@
                                     :as "subtypes"))
   :has-one `((document-type         :via    ,(s-prefix "skos:broader")
                                     :as "supertype"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/document-type-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/document-type-codes/")
   :features '(include-uri)
   :on-path "document-types")
 

--- a/config/resources/dossier-domain.lisp
+++ b/config/resources/dossier-domain.lisp
@@ -71,7 +71,7 @@
               (activity               :via ,(s-prefix "dossier:vindtPlaatsTijdens") ;; Dit is de juiste relatie !! ipv besluitvorming
                                       :inverse t
                                       :as "publication-activities")) ;; this can be translationActivity, signatureActivity, publish )
-  :resource-base (s-url "http://themis.vlaanderen.be/id/procedurestappen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/procedurestap/")
   :features '(include-uri)
   :on-path "subcases")
 

--- a/config/resources/dossier-domain.lisp
+++ b/config/resources/dossier-domain.lisp
@@ -13,7 +13,7 @@
                                 :as "subcases")
               (piece            :via      ,(s-prefix "dossier:Dossier.bestaatUit")
                                 :as "pieces"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/dossiers/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/dossiers/")
   :features '(include-uri)
   :on-path "cases")
 
@@ -23,7 +23,7 @@
                 (:scope-note  :string ,(s-prefix "skos:scopeNote"))
                 (:alt-label   :string ,(s-prefix "skos:altLabel"))
                 (:deprecated  :boolean ,(s-prefix "owl:deprecated")))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/dossier-type-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/dossier-type-codes/")
   :features '(include-uri)
   :on-path "case-types")
 
@@ -71,7 +71,7 @@
               (activity               :via ,(s-prefix "dossier:vindtPlaatsTijdens") ;; Dit is de juiste relatie !! ipv besluitvorming
                                       :inverse t
                                       :as "publication-activities")) ;; this can be translationActivity, signatureActivity, publish )
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/procedurestappen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/procedurestappen/")
   :features '(include-uri)
   :on-path "subcases")
 
@@ -83,7 +83,7 @@
   :has-many `((subcase            :via ,(s-prefix "dct:type")
                                   :inverse t
                                   :as "subcases"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/procedurestap-types/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/procedurestap-types/")
   :features '(include-uri)
   :on-path "subcase-types")
 
@@ -126,7 +126,7 @@
                                   :inverse t
                                   :as "published-by")
                                   )
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/activiteiten/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/activiteiten/")
   :features '(include-uri)
   :on-path "activities")
 
@@ -138,7 +138,7 @@
   :has-many `((activity           :via ,(s-prefix "pub:publicatieStatus")
                                   :inverse t
                                   :as "activities"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/activity-status/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/activity-status/")
   :features '(include-uri)
   :on-path "activity-statuses")
 
@@ -150,7 +150,7 @@
   :has-many `((activity           :via ,(s-prefix "dct:type")
                                   :inverse t
                                   :as "activities"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/activiteit-types/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/activiteit-types/")
   :features '(include-uri)
   :on-path "activity-types")
 
@@ -161,7 +161,7 @@
                                   :as "subcase"))
   :has-many `((agendaitem         :via ,(s-prefix "besluitvorming:genereertAgendapunt")
                                   :as "agendaitems"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/agenderingen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/agenderingen/")
   :features '(include-uri)
   :on-path "agenda-activities")
 
@@ -180,13 +180,13 @@
               (case           :via ,(s-prefix "ext:toegangsniveauVoorDossier")
                               :inverse t
                               :as "cases"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/toegangs-niveaus/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/toegangs-niveaus/")
   :features '(include-uri)
   :on-path "access-levels")
 
 (define-resource person-or-organization ()
   :class (s-prefix "ext:PersonOrOrganization") ;; NOTE: as resource hack for super typing, is person or organization
   :properties `((:type :string ,(s-prefix "rdfs:type")))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/personen/") ;; NOTE: Should in theory never get used, as this is a read-only hack.
+  :resource-base (s-url "http://themis.vlaanderen.be/id/personen/") ;; NOTE: Should in theory never get used, as this is a read-only hack.
   :features '(include-uri)
   :on-path "person-or-organization")

--- a/config/resources/dossier-domain.lisp
+++ b/config/resources/dossier-domain.lisp
@@ -13,7 +13,7 @@
                                 :as "subcases")
               (piece            :via      ,(s-prefix "dossier:Dossier.bestaatUit")
                                 :as "pieces"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/dossiers/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/dossier/")
   :features '(include-uri)
   :on-path "cases")
 
@@ -23,7 +23,7 @@
                 (:scope-note  :string ,(s-prefix "skos:scopeNote"))
                 (:alt-label   :string ,(s-prefix "skos:altLabel"))
                 (:deprecated  :boolean ,(s-prefix "owl:deprecated")))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/dossier-type-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/dossier-type/")
   :features '(include-uri)
   :on-path "case-types")
 
@@ -83,7 +83,7 @@
   :has-many `((subcase            :via ,(s-prefix "dct:type")
                                   :inverse t
                                   :as "subcases"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/procedurestap-types/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/procedurestap-type/")
   :features '(include-uri)
   :on-path "subcase-types")
 
@@ -126,7 +126,7 @@
                                   :inverse t
                                   :as "published-by")
                                   )
-  :resource-base (s-url "http://themis.vlaanderen.be/id/activiteiten/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/activiteit/")
   :features '(include-uri)
   :on-path "activities")
 
@@ -138,7 +138,7 @@
   :has-many `((activity           :via ,(s-prefix "pub:publicatieStatus")
                                   :inverse t
                                   :as "activities"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/activity-status/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/activiteit-status/")
   :features '(include-uri)
   :on-path "activity-statuses")
 
@@ -150,7 +150,7 @@
   :has-many `((activity           :via ,(s-prefix "dct:type")
                                   :inverse t
                                   :as "activities"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/activiteit-types/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/activiteit-type/")
   :features '(include-uri)
   :on-path "activity-types")
 
@@ -161,7 +161,7 @@
                                   :as "subcase"))
   :has-many `((agendaitem         :via ,(s-prefix "besluitvorming:genereertAgendapunt")
                                   :as "agendaitems"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/agenderingen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/agendering/")
   :features '(include-uri)
   :on-path "agenda-activities")
 
@@ -180,13 +180,13 @@
               (case           :via ,(s-prefix "ext:toegangsniveauVoorDossier")
                               :inverse t
                               :as "cases"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/toegangs-niveaus/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/toegangsniveau/")
   :features '(include-uri)
   :on-path "access-levels")
 
 (define-resource person-or-organization ()
   :class (s-prefix "ext:PersonOrOrganization") ;; NOTE: as resource hack for super typing, is person or organization
   :properties `((:type :string ,(s-prefix "rdfs:type")))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/personen/") ;; NOTE: Should in theory never get used, as this is a read-only hack.
+  :resource-base (s-url "http://themis.vlaanderen.be/id/persoon/") ;; NOTE: Should in theory never get used, as this is a read-only hack.
   :features '(include-uri)
   :on-path "person-or-organization")

--- a/config/resources/dossier-domain.lisp
+++ b/config/resources/dossier-domain.lisp
@@ -56,8 +56,6 @@
                                       :as "publication-flow"))
   :has-many `((mandatee               :via ,(s-prefix "ext:heeftBevoegde") ;; NOTE: used mandataris instead of agent
                                       :as "mandatees")
-              (piece                  :via ,(s-prefix "ext:bevatDocumentversie") ;; NOTE: instead of dct:hasPart (mu-cl-resources relation type checking workaround)
-                                      :as "pieces")
               (piece                  :via ,(s-prefix "ext:bevatReedsBezorgdeDocumentversie") ;; NOTE: instead of dct:hasPart (mu-cl-resources relation type checking workaround)
                                       :as "linked-pieces")
               (ise-code               :via ,(s-prefix "ext:heeftInhoudelijkeStructuurElementen")
@@ -65,6 +63,9 @@
               (agenda-activity        :via ,(s-prefix "besluitvorming:vindtPlaatsTijdens") ;; TODO: but others as wel. mu-cl-resources polymorphism limitation. Rename to agenderingVindtPlaatsTijdens ?
                                       :inverse t
                                       :as "agenda-activities")
+              (submission-activity    :via ,(s-prefix "ext:indieningVindtPlaatsTijdens") ;; subpredicate for besluitvorming:vindtPlaatsTijdens
+                                      :inverse t
+                                      :as "submission-activities")
               (agenda-item-treatment  :via ,(s-prefix "ext:beslissingVindtPlaatsTijdens") ;; mu-cl-resources polymorphism limitation. vindtPlaatsTijdens can only be used once !
                                       :inverse t
                                       :as "treatments")
@@ -160,10 +161,28 @@
   :has-one `((subcase             :via ,(s-prefix "besluitvorming:vindtPlaatsTijdens")
                                   :as "subcase"))
   :has-many `((agendaitem         :via ,(s-prefix "besluitvorming:genereertAgendapunt")
-                                  :as "agendaitems"))
+                                  :as "agendaitems")
+             (submission-activity :via ,(s-prefix "prov:wasInformedBy")
+                                  :as "submission-activities"))
   :resource-base (s-url "http://themis.vlaanderen.be/id/agendering/")
   :features '(include-uri)
   :on-path "agenda-activities")
+
+(define-resource submission-activity ()
+  :class (s-prefix "ext:Indieningsactiviteit")
+  :properties `((:start-date      :datetime ,(s-prefix "dossier:Activiteit.startdatum")))
+  :has-one `((subcase             :via ,(s-prefix "ext:indieningVindtPlaatsTijdens") ;; subpredicate for besluitvorming:vindtPlaatsTijdens
+                                  :as "subcase")
+             (agenda-activity     :via ,(s-prefix "prov:wasInformedBy")
+                                  :inverse t
+                                  :as "agenda-activity"))
+  :has-many `((piece              :via ,(s-prefix "prov:generated")
+                                  :as "pieces")
+              (mandatee           :via ,(s-prefix "prov:qualifiedAssociation")
+                                  :as "submitters"))
+  :resource-base (s-url "http://kanselarij.vo.data.gift/id/indieningsactiviteit/")
+  :features '(include-uri)
+  :on-path "submission-activities")
 
 (define-resource access-level ()
   :class (s-prefix "ext:ToegangsniveauCode") ;; NOTE: as well as skos:Concept

--- a/config/resources/email-domain.lisp
+++ b/config/resources/email-domain.lisp
@@ -3,7 +3,7 @@
 ;   :properties `((:id :string ,(s-prefix "nie:identifier")))
 ;   :has-many `((folder :via ,(s-prefix "nie:hasPart")
 ;                     :as "folders"))
-;   :resource-base (s-url "http://kanselarij.vo.data.gift/id/mailboxes/")
+;   :resource-base (s-url "http://themis.vlaanderen.be/id/mailboxes/")
 ;   :features '(include-uri)
 ;   :on-path "mailboxes")
 
@@ -16,7 +16,7 @@
                     :as "emails")
              (folder :via ,(s-prefix "email:hasFolder");;hack, as mu-cl-resources doesn't support superclasses yet (http://oscaf.sourceforge.net/nmo.html#nmo:MailboxDataObject)
                     :as "folders"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/mail-folders/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/mail-folders/")
   :features '(include-uri)
   :on-path "mail-folders")
 
@@ -45,7 +45,7 @@
                     :as "attachments"))
   ;           (email :via ,(s-prefix "nmo:references");;https://tools.ietf.org/html/rfc2822#section-3.6.4
   ;                   :as "references"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/emails/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/emails/")
   :features '(include-uri)
   :on-path "emails")
 
@@ -56,6 +56,6 @@
 ;   :has-one `((email :via ,(s-prefix "nmo:messageHeader")
 ;                          :inverse t
 ;                          :as "email"))
-;   :resource-base (s-url "http://kanselarij.vo.data.gift/id/email-headers/")
+;   :resource-base (s-url "http://themis.vlaanderen.be/id/email-headers/")
 ;   :features '(include-uri)
 ;   :on-path "email-headers")

--- a/config/resources/email-domain.lisp
+++ b/config/resources/email-domain.lisp
@@ -3,7 +3,7 @@
 ;   :properties `((:id :string ,(s-prefix "nie:identifier")))
 ;   :has-many `((folder :via ,(s-prefix "nie:hasPart")
 ;                     :as "folders"))
-;   :resource-base (s-url "http://themis.vlaanderen.be/id/mailboxes/")
+;   :resource-base (s-url "http://themis.vlaanderen.be/id/mailbox/")
 ;   :features '(include-uri)
 ;   :on-path "mailboxes")
 
@@ -16,7 +16,7 @@
                     :as "emails")
              (folder :via ,(s-prefix "email:hasFolder");;hack, as mu-cl-resources doesn't support superclasses yet (http://oscaf.sourceforge.net/nmo.html#nmo:MailboxDataObject)
                     :as "folders"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/mail-folders/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/mail-folder/")
   :features '(include-uri)
   :on-path "mail-folders")
 
@@ -45,7 +45,7 @@
                     :as "attachments"))
   ;           (email :via ,(s-prefix "nmo:references");;https://tools.ietf.org/html/rfc2822#section-3.6.4
   ;                   :as "references"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/emails/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/email/")
   :features '(include-uri)
   :on-path "emails")
 
@@ -56,6 +56,6 @@
 ;   :has-one `((email :via ,(s-prefix "nmo:messageHeader")
 ;                          :inverse t
 ;                          :as "email"))
-;   :resource-base (s-url "http://themis.vlaanderen.be/id/email-headers/")
+;   :resource-base (s-url "http://themis.vlaanderen.be/id/email-header/")
 ;   :features '(include-uri)
 ;   :on-path "email-headers")

--- a/config/resources/files-domain.lisp
+++ b/config/resources/files-domain.lisp
@@ -15,6 +15,6 @@
   :has-many `((activity         :via        ,(s-prefix "ext:gebruiktBestand")
                                 :inverse t
                                 :as "activities"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/files/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/files/")
   :features `(no-pagination-defaults include-uri)
   :on-path "files")

--- a/config/resources/files-domain.lisp
+++ b/config/resources/files-domain.lisp
@@ -15,6 +15,6 @@
   :has-many `((activity         :via        ,(s-prefix "ext:gebruiktBestand")
                                 :inverse t
                                 :as "activities"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/files/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/bestand/")
   :features `(no-pagination-defaults include-uri)
   :on-path "files")

--- a/config/resources/job-domain.lisp
+++ b/config/resources/job-domain.lisp
@@ -7,7 +7,7 @@
   )
   :has-one `((file              :via     ,(s-prefix "prov:generated")
                                 :as "generated"))
-  ; :resource-base (s-url "http://kanselarij.vo.data.gift/id/file-bundling-jobs/")
+  ; :resource-base (s-url "http://themis.vlaanderen.be/id/file-bundling-jobs/")
   :features '(include-uri)
   :on-path "file-bundling-jobs"
 )

--- a/config/resources/mandaat-domain.lisp
+++ b/config/resources/mandaat-domain.lisp
@@ -26,7 +26,7 @@
                                   :as "requested-subcases"))
   :has-one `((person              :via ,(s-prefix "mandaat:isBestuurlijkeAliasVan")
                                   :as "person"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/mandatarissen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/mandatarissen/")
   :features '(include-uri)
   :on-path "mandatees")
 
@@ -38,7 +38,7 @@
   :has-many `((government-field   :via ,(s-prefix "ext:heeftBeleidsDomein")
                                   :inverse t
                                   :as "government-fields"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/beleidsdomeinen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/beleidsdomeinen/")
   :features '(include-uri)
   :on-path "government-domains")
 
@@ -52,7 +52,7 @@
                                   :as "ise-code"))
   :has-one `((government-domain   :via ,(s-prefix "ext:heeftBeleidsDomein")
                                   :as "domain"))                
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/beleidsvelden/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/beleidsvelden/")
   :features '(include-uri)
   :on-path "government-fields")
 
@@ -67,7 +67,7 @@
               (subcase            :via ,(s-prefix "ext:heeftInhoudelijkeStructuurElementen")
                                   :inverse t
                                   :as "subcases"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/ise-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/ise-codes/")
   :features `(no-pagination-defaults include-uri)
   :on-path "ise-codes")
 
@@ -86,7 +86,7 @@
              (signature             :via    ,(s-prefix "ext:bevoegdePersoon")
                                     :inverse t
                                     :as "signature"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/personen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/personen/")
   :features '(include-uri)
   :on-path "persons")
   ;; People here because ember pluralizes persons to people
@@ -97,7 +97,7 @@
   :has-one `((person :via ,(s-prefix "ext:identifier")
                      :inverse t
                      :as "personId"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/identificatoren/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/identificatoren/")
   :features '(include-uri)
   :on-path "identifications")
 
@@ -114,7 +114,7 @@
   :has-many `((meeting      :via       ,(s-prefix "ext:heeftHandtekening")
                             :inverse t
                             :as "meetings"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/signatures/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/signatures/")
   :features '(include-uri)
   :on-path "signatures")
 
@@ -136,6 +136,6 @@
                                     :as "publication-flow")
             (organization :via ,(s-prefix "org:memberOf")
                                     :as "organization"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/contactpersonen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/contactpersonen/")
   :features '(include-uri)
   :on-path "contact-persons")

--- a/config/resources/mandaat-domain.lisp
+++ b/config/resources/mandaat-domain.lisp
@@ -26,7 +26,7 @@
                                   :as "requested-subcases"))
   :has-one `((person              :via ,(s-prefix "mandaat:isBestuurlijkeAliasVan")
                                   :as "person"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/mandatarissen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/mandataris/")
   :features '(include-uri)
   :on-path "mandatees")
 
@@ -38,7 +38,7 @@
   :has-many `((government-field   :via ,(s-prefix "ext:heeftBeleidsDomein")
                                   :inverse t
                                   :as "government-fields"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/beleidsdomeinen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/beleidsdomein/")
   :features '(include-uri)
   :on-path "government-domains")
 
@@ -52,7 +52,7 @@
                                   :as "ise-code"))
   :has-one `((government-domain   :via ,(s-prefix "ext:heeftBeleidsDomein")
                                   :as "domain"))                
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/beleidsvelden/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/beleidsveld/")
   :features '(include-uri)
   :on-path "government-fields")
 
@@ -67,7 +67,7 @@
               (subcase            :via ,(s-prefix "ext:heeftInhoudelijkeStructuurElementen")
                                   :inverse t
                                   :as "subcases"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/ise-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/ise-code/")
   :features `(no-pagination-defaults include-uri)
   :on-path "ise-codes")
 
@@ -86,7 +86,7 @@
              (signature             :via    ,(s-prefix "ext:bevoegdePersoon")
                                     :inverse t
                                     :as "signature"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/personen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/persoon/")
   :features '(include-uri)
   :on-path "persons")
   ;; People here because ember pluralizes persons to people
@@ -97,7 +97,7 @@
   :has-one `((person :via ,(s-prefix "ext:identifier")
                      :inverse t
                      :as "personId"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/identificatoren/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/identificator/")
   :features '(include-uri)
   :on-path "identifications")
 
@@ -114,7 +114,7 @@
   :has-many `((meeting      :via       ,(s-prefix "ext:heeftHandtekening")
                             :inverse t
                             :as "meetings"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/signatures/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/handtekening/")
   :features '(include-uri)
   :on-path "signatures")
 
@@ -136,6 +136,6 @@
                                     :as "publication-flow")
             (organization :via ,(s-prefix "org:memberOf")
                                     :as "organization"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/contactpersonen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/contactpersoon/")
   :features '(include-uri)
   :on-path "contact-persons")

--- a/config/resources/newsletter-domain.lisp
+++ b/config/resources/newsletter-domain.lisp
@@ -23,7 +23,7 @@
                                         :as "themes")
               (piece                    :via      ,(s-prefix "ext:documentenVoorPublicatie")
                                         :as "pieces"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/nieuwsbrief-infos/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/nieuwsbrief-infos/")
   :features '(include-uri)
   :on-path "newsletter-infos")
 
@@ -36,7 +36,7 @@
   :has-many `((newsletter-info  :via    ,(s-prefix "dct:subject")
                                 :inverse t
                                 :as "newsletters"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/thema-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/thema-codes/")
   :features `(no-pagination-defaults include-uri)
   :on-path "themes")
 
@@ -49,6 +49,6 @@
   :has-many `((meeting              :via      ,(s-prefix "ext:heeftMailCampagnes")
                                     :inverse t
                                     :as "meetings"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/mail-campaigns/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/mail-campaigns/")
   :features `(no-pagination-defaults include-uri)
   :on-path "mail-campaigns")

--- a/config/resources/newsletter-domain.lisp
+++ b/config/resources/newsletter-domain.lisp
@@ -23,7 +23,7 @@
                                         :as "themes")
               (piece                    :via      ,(s-prefix "ext:documentenVoorPublicatie")
                                         :as "pieces"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/nieuwsbrief-infos/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/nieuwsbrief-info/")
   :features '(include-uri)
   :on-path "newsletter-infos")
 
@@ -36,7 +36,7 @@
   :has-many `((newsletter-info  :via    ,(s-prefix "dct:subject")
                                 :inverse t
                                 :as "newsletters"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/thema-codes/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/thema/")
   :features `(no-pagination-defaults include-uri)
   :on-path "themes")
 
@@ -49,6 +49,6 @@
   :has-many `((meeting              :via      ,(s-prefix "ext:heeftMailCampagnes")
                                     :inverse t
                                     :as "meetings"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/mail-campaigns/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/mailcampagne/")
   :features `(no-pagination-defaults include-uri)
   :on-path "mail-campaigns")

--- a/config/resources/publicatie-domain.lisp
+++ b/config/resources/publicatie-domain.lisp
@@ -35,7 +35,7 @@
               (contact-person         :via      ,(s-prefix "pub:contactPersoon")
                                       :as "contact-persons"))
               ;; mandatees van subcase bij MR,  ongekende mandatee bij niet via MR
-  :resource-base (s-url "http://themis.vlaanderen.be/id/publicatie-aangelegenheden/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/publicatie-aangelegenheid/")
   :features `(include-uri)
   :on-path "publication-flows")
 
@@ -45,7 +45,7 @@
   :has-one `((publication-flow        :via      ,(s-prefix "pub:numacNummer")
                                       :inverse t
                                       :as "publication-flow"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatie-numac-nummers/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/numac-nummer/")
   :features '(include-uri)
   :on-path "numac-numbers")
 
@@ -56,7 +56,7 @@
   :has-many `((publication-flow    :via    ,(s-prefix "pub:publicatiestatus")
                               :inverse t
                               :as "publications"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatie-statussen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatie-status/")
   :features '(include-uri)
   :on-path "publication-statuses")
 
@@ -76,7 +76,7 @@
   :has-many `((publication-flow   :via ,(s-prefix "dct:type")
                                   :inverse t
                                   :as "publication-flows"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatie-types/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatie-type/")
   :features '(include-uri)
   :on-path "publication-types")
 

--- a/config/resources/publicatie-domain.lisp
+++ b/config/resources/publicatie-domain.lisp
@@ -2,7 +2,7 @@
   :class (s-prefix "pub:Config")
   :properties `((:key        :string ,(s-prefix "skos:prefLabel"))
                 (:value      :string ,(s-prefix "pub:value")))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/publicatie-config/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatie-config/")
   :features '(include-uri)
   :on-path "configs")
 
@@ -35,7 +35,7 @@
               (contact-person         :via      ,(s-prefix "pub:contactPersoon")
                                       :as "contact-persons"))
               ;; mandatees van subcase bij MR,  ongekende mandatee bij niet via MR
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/publicatie-aangelegenheden/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/publicatie-aangelegenheden/")
   :features `(include-uri)
   :on-path "publication-flows")
 
@@ -45,7 +45,7 @@
   :has-one `((publication-flow        :via      ,(s-prefix "pub:numacNummer")
                                       :inverse t
                                       :as "publication-flow"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/publicatie-numac-nummers/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatie-numac-nummers/")
   :features '(include-uri)
   :on-path "numac-numbers")
 
@@ -56,7 +56,7 @@
   :has-many `((publication-flow    :via    ,(s-prefix "pub:publicatiestatus")
                               :inverse t
                               :as "publications"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/publicatie-statussen/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatie-statussen/")
   :features '(include-uri)
   :on-path "publication-statuses")
 
@@ -76,7 +76,7 @@
   :has-many `((publication-flow   :via ,(s-prefix "dct:type")
                                   :inverse t
                                   :as "publication-flows"))
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/concept/publicatie-types/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatie-types/")
   :features '(include-uri)
   :on-path "publication-types")
 

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -74,7 +74,7 @@
 (add-prefix "cogs" "http://vocab.deri.ie/cogs#")
 
 (add-prefix "email" "http://mu.semte.ch/vocabularies/ext/email/")
-(add-prefix "kans" "http://kanselarij.vo.data.gift/core/")
+(add-prefix "kans" "http://themis.vlaanderen.be/core/")
 
 ;;;;;
 ;; You can use the muext: prefix when you're still searching for

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -74,7 +74,7 @@
 (add-prefix "cogs" "http://vocab.deri.ie/cogs#")
 
 (add-prefix "email" "http://mu.semte.ch/vocabularies/ext/email/")
-(add-prefix "kans" "http://themis.vlaanderen.be/core/")
+(add-prefix "kans" "http://kanselarij.vo.data.gift/core/")
 
 ;;;;;
 ;; You can use the muext: prefix when you're still searching for

--- a/config/resources/users-domain.lisp
+++ b/config/resources/users-domain.lisp
@@ -1,6 +1,6 @@
 (define-resource user ()
   :class (s-prefix "foaf:Person")
-  :resource-base (s-url "http://themis.vlaanderen.be/id/gebruikers/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/gebruiker/")
   :properties `((:first-name            :string   ,(s-prefix "foaf:firstName"))
                 (:last-name             :string   ,(s-prefix "foaf:familyName"))
                 (:email-link            :uri      ,(s-prefix "foaf:mbox"))
@@ -18,7 +18,7 @@
 
 (define-resource account ()
   :class (s-prefix "foaf:OnlineAccount")
-  :resource-base (s-url "http://themis.vlaanderen.be/id/accounts/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/account/")
   :properties `((:provider     :via ,(s-prefix "foaf:accountServiceHomepage"))
                 (:vo-id        :via ,(s-prefix "dct:identifier"))
                 (:vo-email     :via ,(s-prefix "ext:email"))
@@ -31,7 +31,7 @@
 
 (define-resource account-group ()
   :class (s-prefix "foaf:Group")
-  :resource-base (s-url "http://themis.vlaanderen.be/id/account-groups/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/account-groep/")
   :properties `((:name  :via ,(s-prefix "foaf:name")))
   :has-many `((user     :via ,(s-prefix "foaf:member")
                         :as "users"))

--- a/config/resources/users-domain.lisp
+++ b/config/resources/users-domain.lisp
@@ -1,6 +1,6 @@
 (define-resource user ()
   :class (s-prefix "foaf:Person")
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/gebruikers/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/gebruikers/")
   :properties `((:first-name            :string   ,(s-prefix "foaf:firstName"))
                 (:last-name             :string   ,(s-prefix "foaf:familyName"))
                 (:email-link            :uri      ,(s-prefix "foaf:mbox"))
@@ -18,7 +18,7 @@
 
 (define-resource account ()
   :class (s-prefix "foaf:OnlineAccount")
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/accounts/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/accounts/")
   :properties `((:provider     :via ,(s-prefix "foaf:accountServiceHomepage"))
                 (:vo-id        :via ,(s-prefix "dct:identifier"))
                 (:vo-email     :via ,(s-prefix "ext:email"))
@@ -31,7 +31,7 @@
 
 (define-resource account-group ()
   :class (s-prefix "foaf:Group")
-  :resource-base (s-url "http://kanselarij.vo.data.gift/id/account-groups/")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/account-groups/")
   :properties `((:name  :via ,(s-prefix "foaf:name")))
   :has-many `((user     :via ,(s-prefix "foaf:member")
                         :as "users"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
       MU_APPLICATION_AUTH_USERID_CLAIM: "vo_id"
       DEBUG_LOG_TOKENSETS: "true"
       LOG_SINK_URL: "http://sink"
-      MU_APPLICATION_RESOURCE_BASE_URI: "http://kanselarij.vo.data.gift/"
+      MU_APPLICATION_RESOURCE_BASE_URI: "http://themis.vlaanderen.be/"
       MU_APPLICATION_AUTH_DEFAULT_GROUP_URI: "http://data.kanselarij.vlaanderen.be/id/group/user"
       REQUEST_TIMEOUT: 5000
     logging: *default-logging
@@ -199,7 +199,7 @@ services:
   user-management-service:
     image: kanselarij/user-management-service:1.1.0
     environment:
-      MU_APPLICATION_RESOURCE_BASE_URI: "http://kanselarij.vo.data.gift/"
+      MU_APPLICATION_RESOURCE_BASE_URI: "http://themis.vlaanderen.be/"
     logging: *default-logging
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,7 @@ services:
     labels:
       - "logging=true"
   agenda-approve-service:
-    image: kanselarij/agenda-approve-service:3.2.2
+    image: kanselarij/agenda-approve-service:3.3.0
     logging: *default-logging
     restart: always
     labels:
@@ -211,7 +211,7 @@ services:
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:3.7.0
+    image: kanselarij/yggdrasil:4.0.0
     environment:
       DIRECT_ENDPOINT: "http://triplestore:8890/sparql"
       RELOAD_ALL_DATA_ON_INIT: "false"
@@ -258,7 +258,7 @@ services:
     labels:
       - "logging=true"
   case-documents-sync:
-    image: kanselarij/case-documents-sync-service:1.1.0
+    image: kanselarij/case-documents-sync-service:1.2.0
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
:point_up: URI bases changed to `themis.vlaanderen.be` + adapted to [Flanders URI recommendations](https://data.vlaanderen.be/cms/URI_RichtlijnenDataVlaanderenBe_V1.pdf).