### PR TITLE
New endpoint for new/modified agenda-item comparison

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -61,6 +61,10 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://document-versions-service/agendaitems/" <> id <> "/pieces/restore"
   end
 
+  get "/agendas/:agenda_id/compare/:compared_agenda_id/agenda-items", @any do
+    Proxy.forward conn, [], "http://agenda-sort-service/agendas/" <> agenda_id <> "/compare/" <> compared_agenda_id <> "/agenda-items"
+  end
+
   get "/agendas/:agenda_id/compare/:compared_agenda_id/agenda-item/:agenda_item_id/pieces", @any do
     Proxy.forward conn, [], "http://agenda-sort-service/agendas/" <> agenda_id <> "/compare/" <> compared_agenda_id <> "/agenda-item/" <> agenda_item_id <> "/documents"
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
     labels:
       - "logging=true"
   agenda-sort-service:
-    image: kanselarij/agenda-sort-service:2.2.0
+    image: kanselarij/agenda-sort-service:2.3.0
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
Extra endpoint for supporting https://github.com/kanselarij-vlaanderen/kaleidos-frontend/pull/778 . Previous functionality is preserved. This should be harmless to merge.