### PR TITLE
Fix/gitattributes line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ root = true
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Force the following filetypes to have unix eols, so Windows does not break them
+*.* text eol=lf
+
+# Denote all files that are truly binary and should not be modified. (bit overkill for this project, but better safe than sorry)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pyc binary
+*.pdf binary
+*.ez binary
+*.bz2 binary
+*.swp binary


### PR DESCRIPTION
Devs on Windows: use this to clone the repo instead of `development`
```
git clone -b fix/gitattributes-line-endings git@github.com:kanselarij-vlaanden/kaleidos-project.git
```
It would also be helpful if a UNIX dev would test this branch, to see if nothing weird happens with this config (it shouldn't, but you never now). Once we're 100% sure, this branch can then be merged into `development` and any future Windows devs should have no issues.

# Workflow used to adapt kaleidos-project for Windows users:

The reason we need to do this is that git automatically converts line endings on checkout and add.
For most projects, this is desired behavior, but in the case of kaleidos (and any other project using the semantic.works stack),
you're mounting these files on Linux Docker machines, and they don't like Windows line endings (CRLF) ...

Specifically, if you clone the repo as usual with
```
git clone git@github.com:kanselarij-vlaanderen/kaleidos-project.git
```

and run the stack as-is on Windows with Docker Desktop, you'll notice that if you go to http://localhost/mock-login ,
the database service will start complaining about 'unparseable queries'.
This is because the .ex files under config now have CRLF endings, which the authorization microservice doesn't understand.

The steps below describe what needs to be done to get the stack working on Windows, and fixes it for all future users as well.

To be clear: I left core.autocrlf = true in my global settings, so I'm 100% sure I never commit any Windows CRLF line endings.
(If you commit Windows line endings, you're gonna have a bad time...)

Now, you could just clone the repo with `--config core.autocrlf=input` as a parameter and be done with it.
```
git clone --config core.autocrlf=input git@github.com:kanselarij-vlaanderen/kaleidos-project.git
```

Then you'll check out LF endings, and any CRLF endings you type will be converted to LF on `git add`.
However, this doesn't guarantee this will work for anyone else in the future. So, let's set this using `.gitattributes`.

The `.gitattributes` will override the config for this repo, for anyone who clones it.
We just have to make sure it does the right thing on both Windows and Linux, and also leaves binary files alone (otherwise it could mess them up).
I found the settings below to work well, based on what I read here https://docs.github.com/en/github/getting-started-with-github/configuring-git-to-handle-line-endings

```
# Handle line endings automatically for files detected as text
# and leave all files detected as binary untouched.
# Set the default behavior, in case people don't have core.autocrlf set.
* text=auto

# Force the following filetypes to have unix eols, so Windows does not break them
*.* text eol=lf

# Denote all files that are truly binary and should not be modified. (bit overkill for this project, but better safe than sorry)
*.png binary
*.jpg binary
*.jpeg binary
*.gif binary
*.ico binary
*.mov binary
*.mp4 binary
*.mp3 binary
*.flv binary
*.fla binary
*.swf binary
*.gz binary
*.zip binary
*.7z binary
*.ttf binary
*.eot binary
*.woff binary
*.pyc binary
*.pdf binary
*.ez binary
*.bz2 binary
*.swp binary
```

I added this .gitattributes file to a new branch called `fix/gitattributes-line-endings`, comitted and pushed it, and then pulled the repo again.

Do this by specifying the right branch (otherwise your default core.autocrlf settings will be used).
```
git clone -b fix/gitattributes-line-endings git@github.com:kanselarij-vlaanden/kaleidos-project.git
```

If you run docker-compose up -d (with all the right .env variables and overrides set of course), you should now be able to run the stack without any problems.

# EXTRA:
I also added an .editorconfig file, which will be read by your editor if you have the right plugin: https://editorconfig.org/
It's highly recommended to install this, as it will keep your code consistent while you're editing.
In this case, it will also make sure you're adding LF line endings, which docker will like.

```
root = true

[*]
end_of_line = lf
charset = utf-8
trim_trailing_whitespace = true
```


# EXTRA 2:
use this in your docker-compose.override.yml to get the frontend exposed and disable non-essential heavy services:
```
services:
  musearch:
    entrypoint: "echo 'service disabled'"
  elasticsearch:
    entrypoint: "echo 'service disabled'"
  yggdrasil:
    entrypoint: "echo 'service disabled'"
  tika:
    entrypoint: "echo 'service disabled'"
  frontend:
    restart: "no"
    ports:
      - "80:80"
```
