### PR TITLE
rewrite 5- & 7-digit numacs to their official 10-digit  counterpart

### DIFF
--- a/config/future_migrations/20210902115600-fix-7-num-numac.sparql
+++ b/config/future_migrations/20210902115600-fix-7-num-numac.sparql
@@ -1,0 +1,40 @@
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX eli: <http://data.europa.eu/eli/ontology#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+        ?identifier skos:notation ?ovrbNumac .
+    }
+}
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+        ?identifier skos:notation ?sbNumac .
+    }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/staatsblad> {
+      ?decision a eli:LegalResource ;
+          eli:id_local ?sbNumac ;
+          eli:date_publication ?sbPubDate .
+  }
+  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+      ?publicationFlow a pub:Publicatieaangelegenheid ;
+          dct:source [] .
+      ?publicationFlow pub:identifier ?identifier .
+      ?identifier skos:notation ?ovrbNumac .
+      FILTER(STRLEN(?ovrbNumac) = 7)
+      FILTER(STRENDS(?ovrbNumac, "00"))
+
+      ?publicationFlow pub:doorlooptPublicatie / dossier:Procedurestap.einddatum ?ovrbPubDateTime .
+      BIND(STRDT(SUBSTR(STR(?ovrbPubDateTime), 1, 10), xsd:date) AS ?ovrbPubDate)
+      
+      BIND(CONCAT(STR(YEAR(?ovrbPubDateTime)), "0", SUBSTR(?ovrbNumac, 1, 5)) AS ?sbNumac)
+  }
+  FILTER(?ovrbPubDate = ?sbPubDate)
+}

--- a/config/future_migrations/20210902120500-fix-5-num-numac.sparql
+++ b/config/future_migrations/20210902120500-fix-5-num-numac.sparql
@@ -1,0 +1,40 @@
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX eli: <http://data.europa.eu/eli/ontology#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+        ?identifier skos:notation ?ovrbNumac .
+    }
+}
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+        ?identifier skos:notation ?sbNumac .
+    }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/staatsblad> {
+      ?decision a eli:LegalResource ;
+          eli:id_local ?sbNumac ;
+          eli:date_publication ?sbPubDate .
+  }
+  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+      ?publicationFlow a pub:Publicatieaangelegenheid ;
+          dct:source [] .
+      ?publicationFlow pub:identifier ?identifier .
+      ?identifier skos:notation ?ovrbNumac .
+      FILTER(STRLEN(?ovrbNumac) = 5)
+
+      ?publicationFlow pub:doorlooptPublicatie / dossier:Procedurestap.einddatum ?ovrbPubDateTime .
+      BIND(STRDT(SUBSTR(STR(?ovrbPubDateTime), 1, 10), xsd:date) AS ?ovrbPubDate)
+      
+      BIND(CONCAT(STR(YEAR(?ovrbPubDateTime)), "0", ?ovrbNumac) AS ?sbNumac)
+  }
+  FILTER(?ovrbPubDate = ?sbPubDate)
+
+}


### PR DESCRIPTION
Adds 2 migrations that rewrite numac-numbers from an abbreviated 5- & 7-digit format to the full 10-digit format used on the staatsblad website. The ovrb-registered publication-date is cross-checked with the one registered in staatsblad for higher confidence. 

Note that this migration was added in a `future_migrations` folder in order to keep them from running on the (production) database until go-live.