### PR TITLE
Feature/KAS-3207 Refactor van eenvoudige ember-data models naar Octane

### DIFF
--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -121,12 +121,7 @@
                 (:alt-label         :string ,(s-prefix "skos:altLabel")))
   :has-many `((document-container   :via    ,(s-prefix "ext:documentType")
                                     :inverse t
-                                    :as "document-containers")
-              (document-type        :via    ,(s-prefix "skos:broader")
-                                    :inverse t
-                                    :as "subtypes"))
-  :has-one `((document-type         :via    ,(s-prefix "skos:broader")
-                                    :as "supertype"))
+                                    :as "document-containers"))
   :resource-base (s-url "http://themis.vlaanderen.be/id/concept/document-type/")
   :features '(include-uri)
   :on-path "document-types")

--- a/config/resources/dossier-domain.lisp
+++ b/config/resources/dossier-domain.lisp
@@ -47,8 +47,6 @@
                                       :as "case")
              (meeting                 :via ,(s-prefix "ext:isAangevraagdVoor")
                                       :as "requested-for-meeting")
-             (access-level            :via ,(s-prefix "ext:toegangsniveauVoorProcedurestap")
-                                      :as "access-level")
              (subcase-type            :via ,(s-prefix "dct:type")
                                       :as "type")
              (mandatee                :via ,(s-prefix "ext:indiener")
@@ -119,15 +117,9 @@
                 (:scope-note  :string ,(s-prefix "skos:scopeNote"))
                 (:alt-label   :string ,(s-prefix "skos:altLabel"))
                 (:priority    :string ,(s-prefix "ext:prioriteit")))
-  :has-many `((subcase        :via ,(s-prefix "ext:toegangsniveauVoorProcedurestap")
+  :has-many `((piece          :via ,(s-prefix "ext:toegangsniveauVoorDocumentVersie")
                               :inverse t
-                              :as "subcases")
-              (piece          :via ,(s-prefix "ext:toegangsniveauVoorDocumentVersie")
-                              :inverse t
-                              :as "pieces")
-              (case           :via ,(s-prefix "ext:toegangsniveauVoorDossier")
-                              :inverse t
-                              :as "cases"))
+                              :as "pieces"))
   :resource-base (s-url "http://themis.vlaanderen.be/id/concept/toegangsniveau/")
   :features '(include-uri)
   :on-path "access-levels")

--- a/config/resources/users-domain.lisp
+++ b/config/resources/users-domain.lisp
@@ -3,8 +3,8 @@
   :resource-base (s-url "http://themis.vlaanderen.be/id/gebruiker/")
   :properties `((:first-name            :string   ,(s-prefix "foaf:firstName"))
                 (:last-name             :string   ,(s-prefix "foaf:familyName"))
-                (:email-link            :uri      ,(s-prefix "foaf:mbox"))
-                (:phone-link            :uri      ,(s-prefix "foaf:phone")))
+                (:email                 :uri      ,(s-prefix "foaf:mbox"))
+                (:phone                 :uri      ,(s-prefix "foaf:phone")))
   :has-one `((account-group             :via      ,(s-prefix "foaf:member")
                                         :inverse t
                                         :as "group")


### PR DESCRIPTION
Jira: https://kanselarij.atlassian.net/jira/software/c/projects/KAS/boards/1?modal=detail&selectedIssue=KAS-3207&assignee=621cf63114cd24006906e31c

Frontend PR: https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1216

Removed unused relations.

Removed subcase has-one access-level

Removed document-type has-one document-type (supertype)

Removed document-type has-many document-type (subtypes)