### PR TITLE
KAS-2306 Remove unused mandatee-service

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -271,10 +271,6 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/file-bundling-jobs/"
   end
 
-  match "/mandatee-service/*path", @any do
-    Proxy.forward conn, path, "http://mandatee-service/"
-  end
-
   match "/publication-flows/search/*path", @any do
     Proxy.forward conn, path, "http://musearch/publication-flows/search/"
   end

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -88,8 +88,6 @@ services:
   database-healthcheck:
     entrypoint: "echo 'service disabled'"
     restart: "no"
-  mandatee-service:
-    restart: "no"
   case-documents-sync:
     restart: "no"
   document-versions-service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,12 +239,6 @@ services:
     restart: always
     labels:
       - "logging=true"
-  mandatee-service:
-    image: kanselarij/mandatee-service:2.1.0
-    logging: *default-logging
-    restart: always
-    labels:
-      - "logging=true"
   case-documents-sync:
     image: kanselarij/case-documents-sync-service:1.2.0
     logging: *default-logging


### PR DESCRIPTION
Used grep locally to check for presence of `mandatee-service` or `mandateeIsCompetentOnFutureAgendaItem` across all repos:
`rg -n '(mandatee-service|mandateeIsCompetentOnFutureAgendaItem)' */`

Search using github:

https://github.com/search?q=org%3Akanselarij-vlaanderen+mandateeIsCompetentOnFutureAgendaItem&type=code
https://github.com/search?q=org%3Akanselarij-vlaanderen+mandatee-service&type=code

Only occurrences were in docker-compose files and dispatcher, removed those.

After merge, archive repo: https://github.com/kanselarij-vlaanderen/mandatee-service