### PR TITLE
Feature/kas 3325 align service names in docker compose yml met common practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker-compose -f docker-compose.yml -f docker-compose.development.yml up
 
 *Pro tip: The stack consists of some services such as `mu-search` that can potentially consume a lot of resources and often aren't required for basic development-tasks. Adding the following snippet to your `docker-compose.override.yml`-file under `services`, will disable the most resource-consuming services.*
 ```yml
-  musearch:
+  search:
     entrypoint: "echo 'service disabled'"
   tika:
     entrypoint: "echo 'service disabled'"

--- a/config/authorization/delta.ex
+++ b/config/authorization/delta.ex
@@ -11,7 +11,7 @@ defmodule Delta.Config do
   @spec targets() :: [String.t]
   def targets do
     [
-      "http://deltanotifier"
+      "http://delta-notifier"
      ]
   end
 

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -6,7 +6,7 @@ export default [
       }
     },
     callback: {
-      url: 'http://musearch/update',
+      url: 'http://search/update',
       method: 'POST'
     },
     options: {
@@ -59,7 +59,7 @@ export default [
       }
     },
     callback: {
-      url: 'http://file-bundling-service/delta',
+      url: 'http://file-bundling/delta',
       method: 'POST'
     },
     options: {
@@ -79,7 +79,7 @@ export default [
       }
     },
     callback: {
-      url: 'http://file-bundling-service/delta',
+      url: 'http://file-bundling/delta',
       method: 'POST'
     },
     options: {

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -10,51 +10,51 @@ defmodule Dispatcher do
   @json %{ accept: %{ json: true } }
 
   match "/agendaitems/search/*path", @any do
-    Proxy.forward conn, path, "http://musearch/agendaitems/search/"
+    Proxy.forward conn, path, "http://search/agendaitems/search/"
   end
 
   match "/agendaitems/index/*path", @any do
-    Proxy.forward conn, path, "http://musearch/agendaitems/search/"
+    Proxy.forward conn, path, "http://search/agendaitems/search/"
   end
 
   match "/agendaitems/invalidate/*path", @any do
-    Proxy.forward conn, path, "http://musearch/agendaitems/invalidate/"
+    Proxy.forward conn, path, "http://search/agendaitems/invalidate/"
   end
 
   match "/cases/search/*path", @any do
-    Proxy.forward conn, path, "http://musearch/cases/search/"
+    Proxy.forward conn, path, "http://search/cases/search/"
   end
 
   match "/cases/index/*path", @any do
-    Proxy.forward conn, path, "http://musearch/cases/search/"
+    Proxy.forward conn, path, "http://search/cases/search/"
   end
 
   match "/cases/invalidate/*path", @any do
-    Proxy.forward conn, path, "http://musearch/cases/invalidate/"
+    Proxy.forward conn, path, "http://search/cases/invalidate/"
   end
 
-  match "/musearch/settings/*path", @any do
-    Proxy.forward conn, path, "http://musearch/settings/"
+  match "/search/settings/*path", @any do
+    Proxy.forward conn, path, "http://search/settings/"
   end
 
   put "/agendaitems/:id/pieces", @any do
-    Proxy.forward conn, [], "http://document-versions-service/agendaitems/" <> id <> "/documents"
+    Proxy.forward conn, [], "http://document-versions/agendaitems/" <> id <> "/documents"
   end
 
   put "/agendaitems/:id/pieces/restore", @any do
-    Proxy.forward conn, [], "http://document-versions-service/agendaitems/" <> id <> "/pieces/restore"
+    Proxy.forward conn, [], "http://document-versions/agendaitems/" <> id <> "/pieces/restore"
   end
 
   get "/agendas/:agenda_id/compare/:compared_agenda_id/agenda-items", @any do
-    Proxy.forward conn, [], "http://agenda-sort-service/agendas/" <> agenda_id <> "/compare/" <> compared_agenda_id <> "/agenda-items"
+    Proxy.forward conn, [], "http://agenda-sort/agendas/" <> agenda_id <> "/compare/" <> compared_agenda_id <> "/agenda-items"
   end
 
   get "/agendas/:agenda_id/compare/:compared_agenda_id/agenda-item/:agenda_item_id/pieces", @any do
-    Proxy.forward conn, [], "http://agenda-sort-service/agendas/" <> agenda_id <> "/compare/" <> compared_agenda_id <> "/agenda-item/" <> agenda_item_id <> "/documents"
+    Proxy.forward conn, [], "http://agenda-sort/agendas/" <> agenda_id <> "/compare/" <> compared_agenda_id <> "/agenda-item/" <> agenda_item_id <> "/documents"
   end
 
   post "/agendas/:id/agendaitems/pieces/files/archive", @any do
-    Proxy.forward conn, [], "http://file-bundling-job-creation-service/agendas/" <> id <> "/agendaitems/documents/files/archive"
+    Proxy.forward conn, [], "http://file-bundling-job-creation/agendas/" <> id <> "/agendaitems/documents/files/archive"
   end
   match "/agendas/*path", @any do
     Proxy.forward conn, path, "http://cache/agendas/"
@@ -177,7 +177,7 @@ defmodule Dispatcher do
   end
 
   match "/newsletter-infos/search/*path", @any do
-    Proxy.forward conn, path, "http://musearch/newsletter-infos/search/"
+    Proxy.forward conn, path, "http://search/newsletter-infos/search/"
   end
 
   match "/newsletter-infos/*path", @any do
@@ -201,19 +201,19 @@ defmodule Dispatcher do
   end
 
   match "/agenda-sort/*path", @any do
-    Proxy.forward conn, path, "http://agenda-sort-service/"
+    Proxy.forward conn, path, "http://agenda-sort/"
   end
 
   match "/custom-subcases/*path", @any do
-    Proxy.forward conn, path, "http://custom-subcases-service/"
+    Proxy.forward conn, path, "http://custom-subcases/"
   end
 
-  match "/session-service/*path", @any do
-    Proxy.forward conn, path, "http://session-number-service/"
+  match "/session-number/*path", @any do
+    Proxy.forward conn, path, "http://session-number/"
   end
 
   match "/agenda-approve/*path", @any do
-    Proxy.forward conn, path, "http://agenda-approve-service/"
+    Proxy.forward conn, path, "http://agenda-approve/"
   end
 
   match "/account-groups/*path", @any do
@@ -247,8 +247,8 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/alerts/"
   end
 
-  match "/user-management-service/*path", @any do
-    Proxy.forward conn, path, "http://user-management-service/"
+  match "/user-management/*path", @any do
+    Proxy.forward conn, path, "http://user-management/"
   end
 
   match "/alert-types/*path", @any do
@@ -260,7 +260,7 @@ defmodule Dispatcher do
   end
 
   match "/newsletter/*path", @any do
-    Proxy.forward conn, path, "http://newsletter-service/"
+    Proxy.forward conn, path, "http://newsletter/"
   end
 
   match "/mail-campaigns/*path", @any do
@@ -271,12 +271,12 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/file-bundling-jobs/"
   end
 
-  match "/mandatee-service/*path", @any do
-    Proxy.forward conn, path, "http://mandatee-service/"
+  match "/mandatee/*path", @any do
+    Proxy.forward conn, path, "http://mandatee/"
   end
 
   match "/publication-flows/search/*path", @any do
-    Proxy.forward conn, path, "http://musearch/publication-flows/search/"
+    Proxy.forward conn, path, "http://search/publication-flows/search/"
   end
 
   match "/publication-flows/*path", @any do

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -18,7 +18,7 @@ services:
     - "80:80"
   dispatcher:
     restart: "no"
-  migrations-service:
+  migrations:
     restart: "no"
   database:
     restart: "no"
@@ -38,7 +38,7 @@ services:
     ports:
       - "8890:8890"
     restart: "no"
-  musearch:
+  search:
     restart: "no"
     environment:
       NUMBER_OF_THREADS: 4
@@ -47,7 +47,7 @@ services:
     restart: "no"
   tika:
     restart: "no"
-  deltanotifier:
+  delta-notifier:
     restart: "no"
   cache-warmup:
     restart: "no"
@@ -59,40 +59,40 @@ services:
     restart: "no"
   file:
     restart: "no"
-  session-number-service:
+  session-number:
     restart: "no"
-  agenda-sort-service:
+  agenda-sort:
     restart: "no"
-  custom-subcases-service:
+  custom-subcases:
     restart: "no"
-  agenda-approve-service:
+  agenda-approve:
     restart: "no"
   mocklogin:
     restart: "no"
   login:
     entrypoint: "echo 'service disabled'"
     restart: "no"
-  newsletter-service:
+  newsletter:
     entrypoint: "echo 'service disabled'"
     restart: "no"
-  user-management-service:
+  user-management:
     restart: "no"
   yggdrasil:
     restart: "no"
   sink:
     restart: "no"
-  file-bundling-service:
+  file-bundling:
     restart: "no"
-  file-bundling-job-creation-service:
+  file-bundling-job-creation:
     restart: "no"
   database-healthcheck:
     entrypoint: "echo 'service disabled'"
     restart: "no"
-  mandatee-service:
+  mandatee:
     restart: "no"
   case-documents-sync:
     restart: "no"
-  document-versions-service:
+  document-versions:
     restart: "no"
   document-release:
     restart: "no"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,7 +3,7 @@ services:
   triplestore:
     volumes:
       - ./testdata/db:/data
-  musearch:
+  search:
     volumes:
       - ./testdata/files:/data
     environment:
@@ -20,7 +20,7 @@ services:
   # range-file:
   #   volumes:
   #     - ./testdata/files:/share
-  file-bundling-service:
+  file-bundling:
     volumes:
       - ./testdata/files:/share
   # The DELTA_INTERVAL_MS is the value that yggdrasil waits between runs in milliseconds

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     restart: always
     labels:
       - "logging=true"
-  migrations-service:
+  migrations:
     image: semtech/mu-migrations-service:0.7.0
     volumes:
       - ./config/migrations:/data/migrations
@@ -75,7 +75,7 @@ services:
     restart: always
     labels:
       - "logging=true"
-  musearch:
+  search:
     image: semtech/mu-search:0.8.0-beta.3
     volumes:
       - ./config/search:/config
@@ -103,7 +103,7 @@ services:
     restart: always
     labels:
       - "logging=true"
-  deltanotifier:
+  delta-notifier:
     image: semtech/mu-delta-notifier:0.1.0
     volumes:
         - ./config/delta:/config
@@ -146,25 +146,25 @@ services:
     restart: always
     labels:
       - "logging=true"
-  session-number-service:
+  session-number:
     image: kanselarij/session-number-service:1.2.0
     logging: *default-logging
     restart: always
     labels:
       - "logging=true"
-  agenda-sort-service:
+  agenda-sort:
     image: kanselarij/agenda-sort-service:2.3.0
     logging: *default-logging
     restart: always
     labels:
       - "logging=true"
-  custom-subcases-service:
+  custom-subcases:
     image: kanselarij/custom-subcases-service:2.2.1
     logging: *default-logging
     restart: always
     labels:
       - "logging=true"
-  agenda-approve-service:
+  agenda-approve:
     image: kanselarij/agenda-approve-service:4.1.0
     logging: *default-logging
     restart: always
@@ -193,13 +193,13 @@ services:
     restart: always
     labels:
       - "logging=true"
-  newsletter-service:
+  newsletter:
     image: kanselarij/newsletter-service:3.1.0
     logging: *default-logging
     restart: always
     labels:
       - "logging=true"
-  user-management-service:
+  user-management:
     image: kanselarij/user-management-service:1.1.0
     environment:
       MU_APPLICATION_RESOURCE_BASE_URI: "http://themis.vlaanderen.be/"
@@ -219,7 +219,7 @@ services:
     restart: always
     labels:
       - "logging=true"
-  file-bundling-service:
+  file-bundling:
     image: kanselarij/file-bundling-service:2.1.3
     volumes:
       - ./data/files:/share
@@ -227,7 +227,7 @@ services:
     restart: always
     labels:
       - "logging=true"
-  file-bundling-job-creation-service:
+  file-bundling-job-creation:
     image: kanselarij/file-bundling-job-creation-service:0.1.6
     logging: *default-logging
     restart: always
@@ -239,7 +239,7 @@ services:
     restart: always
     labels:
       - "logging=true"
-  mandatee-service:
+  mandatee:
     image: kanselarij/mandatee-service:2.1.0
     logging: *default-logging
     restart: always
@@ -251,7 +251,7 @@ services:
     restart: always
     labels:
       - "logging=true"
-  document-versions-service:
+  document-versions:
     image: kanselarij/document-versions-service:0.2.1
     logging: *default-logging
     restart: always

--- a/scripts/delete-cache.sh
+++ b/scripts/delete-cache.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 echo "warning this will run queries on the triplestore and delete containers, you have 5 seconds to press ctrl+c"
 sleep 5
-docker-compose rm -fs elasticsearch  musearch
+docker-compose rm -fs elasticsearch search
 rm -rf data/elasticsearch
 docker-compose exec -T triplestore isql-v <<EOF
 SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };
 exec('checkpoint');
 exit;
 EOF
-docker-compose up -d --remove-orphan elasticsearch musearch
+docker-compose up -d --remove-orphan elasticsearch search

--- a/scripts/delete_index_reindex.sh
+++ b/scripts/delete_index_reindex.sh
@@ -2,13 +2,13 @@
 
 echo 'this script is for reference only';
 echo 'first step:';
-echo 'add 127.0.0.1:7070:80 to the ports section of musearch';
+echo 'add 127.0.0.1:7070:80 to the ports section of search';
 echo 'then change the correct variables to reindex';
 echo 'then execute the curl call from the script';
 
 exit;
 
-#  musearch:
+#  search:
 #    ports:
 #      - 127.0.0.1:7070:80
 

--- a/scripts/reset-elastic-test.sh
+++ b/scripts/reset-elastic-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "warning this will run queries on the triplestore and delete containers, you have 5 seconds to press ctrl+c"
 sleep 5
-docker-compose -f docker-compose.yml -f docker-compose.development.yml -f docker-compose.test.yml -f docker-compose.override.yml rm -fs elasticsearch  musearch
+docker-compose -f docker-compose.yml -f docker-compose.development.yml -f docker-compose.test.yml -f docker-compose.override.yml rm -fs elasticsearch search
 rm -rf testdata/elasticsearch
 docker-compose -f docker-compose.yml -f docker-compose.development.yml -f docker-compose.test.yml -f docker-compose.override.yml exec -T triplestore isql-v <<EOF
 SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };

--- a/scripts/reset-elastic.sh
+++ b/scripts/reset-elastic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "warning this will run queries on the triplestore and delete containers, you have 5 seconds to press ctrl+c"
 sleep 5
-docker-compose rm -fs elasticsearch  musearch
+docker-compose rm -fs elasticsearch search
 rm -rf data/elasticsearch
 docker-compose exec -T triplestore isql-v <<EOF
 SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };


### PR DESCRIPTION
Frontend PR: https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1294

Changes config files to update container names of services (no `-service` suffix, `delta-notifier` instead of `delta-notifier`, `search` instead of `mu-search`, ...)