### PR TITLE
KAS-2429 Add migrations for vergaderactiviteit-types from Kaleidos to Themis

### DIFF
--- a/config/migrations/20220419144229-themis-vergaderactiviteit-types-ordering-public.graph
+++ b/config/migrations/20220419144229-themis-vergaderactiviteit-types-ordering-public.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20220419144229-themis-vergaderactiviteit-types-ordering-public.ttl
+++ b/config/migrations/20220419144229-themis-vergaderactiviteit-types-ordering-public.ttl
@@ -1,0 +1,17 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+
+<http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/ef51c9d5-8b45-4501-9dcd-3e00ccff524f>
+    schema:position 1 . # Ministerraad
+
+<http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/2387564a-0897-4a62-9b9a-d1755eece7af>
+    schema:position 2 . # Elektronische procedure
+
+<http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/62a0a3c3-44ed-4f35-8b46-1d50616ad42c>
+    schema:position 3 . # Bijzondere ministerraad
+
+<http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/9b4701f8-a136-4009-94c6-d64fdc96b9a2>
+    schema:position 4 . # Ministerraad - Plan Vlaamse Veerkracht
+
+<http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/30d6a064-8cca-4485-8b37-7ab2357d931d> # Annex
+    skos:narrower <http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/9b4701f8-a136-4009-94c6-d64fdc96b9a2> .

--- a/config/migrations/20220419144229-themis-vergaderactiviteit-types-ordering-public.ttl
+++ b/config/migrations/20220419144229-themis-vergaderactiviteit-types-ordering-public.ttl
@@ -5,6 +5,7 @@
     schema:position 1 . # Ministerraad
 
 <http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/2387564a-0897-4a62-9b9a-d1755eece7af>
+    skos:altLabel "Ministerraad via elektronische procedure"@nl ;
     schema:position 2 . # Elektronische procedure
 
 <http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/62a0a3c3-44ed-4f35-8b46-1d50616ad42c>

--- a/config/migrations/20220419144230-themis-vergaderactiviteit-types-ordering-kanselarij.graph
+++ b/config/migrations/20220419144230-themis-vergaderactiviteit-types-ordering-kanselarij.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/organizations/kanselarij

--- a/config/migrations/20220419144230-themis-vergaderactiviteit-types-ordering-kanselarij.ttl
+++ b/config/migrations/20220419144230-themis-vergaderactiviteit-types-ordering-kanselarij.ttl
@@ -1,0 +1,17 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+
+<http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/ef51c9d5-8b45-4501-9dcd-3e00ccff524f>
+    schema:position 1 . # Ministerraad
+
+<http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/2387564a-0897-4a62-9b9a-d1755eece7af>
+    schema:position 2 . # Elektronische procedure
+
+<http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/62a0a3c3-44ed-4f35-8b46-1d50616ad42c>
+    schema:position 3 . # Bijzondere ministerraad
+
+<http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/9b4701f8-a136-4009-94c6-d64fdc96b9a2>
+    schema:position 4 . # Ministerraad - Plan Vlaamse Veerkracht
+
+<http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/30d6a064-8cca-4485-8b37-7ab2357d931d> # Annex
+    skos:narrower <http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/9b4701f8-a136-4009-94c6-d64fdc96b9a2> .

--- a/config/migrations/20220419144230-themis-vergaderactiviteit-types-ordering-kanselarij.ttl
+++ b/config/migrations/20220419144230-themis-vergaderactiviteit-types-ordering-kanselarij.ttl
@@ -5,6 +5,7 @@
     schema:position 1 . # Ministerraad
 
 <http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/2387564a-0897-4a62-9b9a-d1755eece7af>
+    skos:altLabel "Ministerraad via elektronische procedure"@nl ;
     schema:position 2 . # Elektronische procedure
 
 <http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/62a0a3c3-44ed-4f35-8b46-1d50616ad42c>

--- a/config/migrations/20220419144231-migratie-kaleidos-naar-themis-vergaderactiviteit-types.sparql
+++ b/config/migrations/20220419144231-migratie-kaleidos-naar-themis-vergaderactiviteit-types.sparql
@@ -1,0 +1,98 @@
+PREFIX kkind: <http://kanselarij.vo.data.gift/id/concept/ministerraad-type-codes/>
+PREFIX tkind: <http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX schema: <http://schema.org/>
+
+DELETE WHERE {
+  GRAPH ?g {
+    <http://kanselarij.vo.data.gift/id/concept-scheme/668f0c19-3864-4e96-9dd3-de806fd53357> ?p00 ?o00 .
+    kkind:A5D6B7A8-2F9C-44B6-B3BE-98D80B426254 ?p11 ?o11 . # Ministerraad
+    kkind:406F2ECA-524D-47DC-B889-651893135456 ?p12 ?o12 . # Elektronische procedure
+    kkind:7D8E35BE-E5D1-494F-B5F9-51B07875B96F ?p13 ?o13 . # Bijzondere ministerraad
+    kkind:1d16cb70-0ae9-489e-bf97-c74897222e3c ?p14 ?o14 . # Ministerraad - Plan Vlaamse Veerkracht
+    kkind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce ?p15 ?o15 . # Annex
+  }
+};
+
+DELETE {
+  GRAPH ?g {
+    ?s1 ?p1 kkind:406F2ECA-524D-47DC-B889-651893135456 .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s1 ?p1 tkind:2387564a-0897-4a62-9b9a-d1755eece7af .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s1 ?p1 kkind:406F2ECA-524D-47DC-B889-651893135456 .
+  }
+};
+
+
+DELETE {
+  GRAPH ?g {
+    ?s2 ?p2 kkind:7D8E35BE-E5D1-494F-B5F9-51B07875B96F .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s2 ?p2 tkind:62a0a3c3-44ed-4f35-8b46-1d50616ad42c .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s2 ?p2 kkind:7D8E35BE-E5D1-494F-B5F9-51B07875B96F .
+  }
+};
+
+DELETE {
+  GRAPH ?g {
+    ?s3 ?p3 kkind:A5D6B7A8-2F9C-44B6-B3BE-98D80B426254 .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s3 ?p3 tkind:ef51c9d5-8b45-4501-9dcd-3e00ccff524f .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s3 ?p3 kkind:A5D6B7A8-2F9C-44B6-B3BE-98D80B426254 .
+  }
+};
+
+DELETE {
+  GRAPH ?g {
+    ?s4 ?p4 kkind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s4 ?p4 tkind:30d6a064-8cca-4485-8b37-7ab2357d931d .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s4 ?p4 kkind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce .
+  }
+};
+
+DELETE {
+  GRAPH ?g {
+    ?s5 ?p5 kkind:1d16cb70-0ae9-489e-bf97-c74897222e3c .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s5 ?p5 tkind:9b4701f8-a136-4009-94c6-d64fdc96b9a2 .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s5 ?p5 kkind:1d16cb70-0ae9-489e-bf97-c74897222e3c .
+  }
+};

--- a/config/migrations/20220419144231-migratie-kaleidos-naar-themis-vergaderactiviteit-types.sparql
+++ b/config/migrations/20220419144231-migratie-kaleidos-naar-themis-vergaderactiviteit-types.sparql
@@ -1,9 +1,5 @@
 PREFIX kkind: <http://kanselarij.vo.data.gift/id/concept/ministerraad-type-codes/>
 PREFIX tkind: <http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/>
-PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-PREFIX schema: <http://schema.org/>
 
 DELETE WHERE {
   GRAPH ?g {
@@ -18,81 +14,23 @@ DELETE WHERE {
 
 DELETE {
   GRAPH ?g {
-    ?s1 ?p1 kkind:406F2ECA-524D-47DC-B889-651893135456 .
+    ?s ?p ?kaleidosKind .
   }
 }
 INSERT {
   GRAPH ?g {
-    ?s1 ?p1 tkind:2387564a-0897-4a62-9b9a-d1755eece7af .
+    ?s ?p ?themisKind .
   }
 }
 WHERE {
   GRAPH ?g {
-    ?s1 ?p1 kkind:406F2ECA-524D-47DC-B889-651893135456 .
-  }
-};
-
-
-DELETE {
-  GRAPH ?g {
-    ?s2 ?p2 kkind:7D8E35BE-E5D1-494F-B5F9-51B07875B96F .
-  }
-}
-INSERT {
-  GRAPH ?g {
-    ?s2 ?p2 tkind:62a0a3c3-44ed-4f35-8b46-1d50616ad42c .
+    ?s ?p ?kaleidosKind .
+    VALUES (?kaleidosKind ?themisKind) {
+      (kkind:A5D6B7A8-2F9C-44B6-B3BE-98D80B426254 tkind:ef51c9d5-8b45-4501-9dcd-3e00ccff524f) # Ministerraad
+      (kkind:406F2ECA-524D-47DC-B889-651893135456 tkind:2387564a-0897-4a62-9b9a-d1755eece7af) # Elektronische procedure
+      (kkind:7D8E35BE-E5D1-494F-B5F9-51B07875B96F tkind:62a0a3c3-44ed-4f35-8b46-1d50616ad42c) # Bijzondere ministerraad
+      (kkind:1d16cb70-0ae9-489e-bf97-c74897222e3c tkind:9b4701f8-a136-4009-94c6-d64fdc96b9a2) # PVV
+      (kkind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce tkind:30d6a064-8cca-4485-8b37-7ab2357d931d) # Annex
+    }
   }
 }
-WHERE {
-  GRAPH ?g {
-    ?s2 ?p2 kkind:7D8E35BE-E5D1-494F-B5F9-51B07875B96F .
-  }
-};
-
-DELETE {
-  GRAPH ?g {
-    ?s3 ?p3 kkind:A5D6B7A8-2F9C-44B6-B3BE-98D80B426254 .
-  }
-}
-INSERT {
-  GRAPH ?g {
-    ?s3 ?p3 tkind:ef51c9d5-8b45-4501-9dcd-3e00ccff524f .
-  }
-}
-WHERE {
-  GRAPH ?g {
-    ?s3 ?p3 kkind:A5D6B7A8-2F9C-44B6-B3BE-98D80B426254 .
-  }
-};
-
-DELETE {
-  GRAPH ?g {
-    ?s4 ?p4 kkind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce .
-  }
-}
-INSERT {
-  GRAPH ?g {
-    ?s4 ?p4 tkind:30d6a064-8cca-4485-8b37-7ab2357d931d .
-  }
-}
-WHERE {
-  GRAPH ?g {
-    ?s4 ?p4 kkind:d36138a9-07f0-4df6-bbf0-abd51a24e4ce .
-  }
-};
-
-DELETE {
-  GRAPH ?g {
-    ?s5 ?p5 kkind:1d16cb70-0ae9-489e-bf97-c74897222e3c .
-  }
-}
-INSERT {
-  GRAPH ?g {
-    ?s5 ?p5 tkind:9b4701f8-a136-4009-94c6-d64fdc96b9a2 .
-  }
-}
-WHERE {
-  GRAPH ?g {
-    ?s5 ?p5 kkind:1d16cb70-0ae9-489e-bf97-c74897222e3c .
-  }
-};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
     labels:
       - "logging=true"
   session-number:
-    image: kanselarij/session-number-service:1.2.0
+    image: kanselarij/session-number-service:1.3.0
     logging: *default-logging
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,7 +194,7 @@ services:
     labels:
       - "logging=true"
   newsletter:
-    image: kanselarij/newsletter-service:3.1.0
+    image: kanselarij/newsletter-service:3.2.0
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
Frontend PR: https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1299
newsletter-service PR: https://github.com/kanselarij-vlaanderen/newsletter-service/pull/44
session-number-service PR: https://github.com/kanselarij-vlaanderen/session-number-service/pull/7

Adds migrations from Kaleidos MinisterraadTypes to Themis vergaderactiviteit-types. Adds the `schema:position` to the Themis concepts & `skos:narrower` from Annex to PVV.