### PR TITLE
KAS-3164: Role cleanup

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -236,9 +236,6 @@ defmodule Acl.UserGroups.Config do
           constraint: %ResourceConstraint{
             resource_types: [
               "http://www.w3.org/ns/person#Person",
-              "http://xmlns.com/foaf/0.1/OnlineAccount",
-              "http://xmlns.com/foaf/0.1/Person",
-              "http://xmlns.com/foaf/0.1/Group",
             ] ++ unconfidential_resource_types() ++
               static_unconfidential_code_list_types() ++
               user_account_resource_types()

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -10,7 +10,7 @@ alias Acl.GroupSpec.GraphCleanup, as: GraphCleanup
 
 defmodule Acl.UserGroups.Config do
 
-  defp access_by_role( group_uris ) do
+  defp access_by_group( group_uris ) do
     %AccessByQuery{
       vars: [],
       query: "PREFIX session: <http://mu.semte.ch/vocabularies/session/>
@@ -217,7 +217,7 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-intern-overheid-read",
         useage: [:read, :write, :read_for_write],
-        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/overheid>" ),
+        access: access_by_group( "<http://data.kanselarij.vlaanderen.be/id/group/overheid>" ),
         graphs: [
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/organizations/intern-overheid",
@@ -260,7 +260,7 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-admin-roles",
         useage: [:read, :write, :read_for_write],
-        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/admin>" ),
+        access: access_by_group( "<http://data.kanselarij.vlaanderen.be/id/group/admin>" ),
         graphs: [
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/organizations/admin",
@@ -273,7 +273,7 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-intern-regering-read",
         useage: [:read, :write, :read_for_write],
-        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/kabinet>" ),
+        access: access_by_group( "<http://data.kanselarij.vlaanderen.be/id/group/kabinet>" ),
         graphs: [
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/organizations/intern-regering",
@@ -286,7 +286,7 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-minister-read",
         useage: [:read, :write, :read_for_write],
-        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/minister>" ),
+        access: access_by_group( "<http://data.kanselarij.vlaanderen.be/id/group/minister>" ),
         graphs: [
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/organizations/minister",
@@ -299,7 +299,7 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-kanselarij-all",
         useage: [:read, :write, :read_for_write],
-        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/admin>
+        access: access_by_group( "<http://data.kanselarij.vlaanderen.be/id/group/admin>
                                  <http://data.kanselarij.vlaanderen.be/id/group/kanselarij>"),
         graphs: [
           %GraphSpec{
@@ -329,7 +329,7 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "ovrb",
         useage: [:read, :write, :read_for_write],
-        access: access_by_role( "<http://data.kanselarij.vlaanderen.be/id/group/OVRB>" ), # TODO: Read access on whole "kanselarij"-graph for now. Recent kanselarij-data will have separate graph later on
+        access: access_by_group( "<http://data.kanselarij.vlaanderen.be/id/group/OVRB>" ), # TODO: Read access on whole "kanselarij"-graph for now. Recent kanselarij-data will have separate graph later on
         graphs: [
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/organizations/kanselarij",

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -236,9 +236,7 @@ defmodule Acl.UserGroups.Config do
         graphs: [ %GraphSpec{
           graph: "http://mu.semte.ch/graphs/public",
           constraint: %ResourceConstraint{
-            resource_types: unconfidential_resource_types() ++
-              static_unconfidential_code_list_types() ++
-              user_account_resource_types() # TODO: user_account_resource_types don't belong here. Needs data-redistribution over different graphs-work.
+            resource_types: user_account_resource_types() # TODO: user_account_resource_types don't belong here. Needs data-redistribution over different graphs-work.
             }
           },
         ]

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -59,7 +59,8 @@ defmodule Acl.UserGroups.Config do
       "http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt",
       "http://data.vlaanderen.be/ns/besluit#Vergaderactiviteit",
       "http://data.vlaanderen.be/ns/besluitvorming#Agendering",
-      "http://mu.semte.ch/vocabularies/ext/Indieningsactiviteit"
+      "http://mu.semte.ch/vocabularies/ext/Indieningsactiviteit",
+      "http://mu.semte.ch/vocabularies/ext/Goedkeuring",
     ]
   end
 
@@ -147,7 +148,6 @@ defmodule Acl.UserGroups.Config do
   # Also insert your type as ext:PublicClass
   defp unconfidential_resource_types() do
     [
-      "http://mu.semte.ch/vocabularies/ext/Goedkeuring",
       "http://mu.semte.ch/vocabularies/ext/DocumentIdentifier", # TODO: check if this type is in use.
       "http://data.vlaanderen.be/ns/mandaat#Mandaat",
       "http://data.vlaanderen.be/ns/mandaat#Mandataris",

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -22,18 +22,6 @@ defmodule Acl.UserGroups.Config do
     }
   end
 
-  defp direct_write_on_public( group_string ) do
-    %AccessByQuery{
-      vars: [],
-      query: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      SELECT ?session_role WHERE {
-        <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group;
-                     ext:sessionRole ?session_role.
-        FILTER( ?session_role IN (\"#{group_string}\") )
-      } LIMIT 1" }
-  end
-
   defp generic_besluitvorming_resource_types() do
     [
       "https://data.vlaanderen.be/ns/dossier#Dossier",

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -234,9 +234,7 @@ defmodule Acl.UserGroups.Config do
         graphs: [ %GraphSpec{
           graph: "http://mu.semte.ch/graphs/public",
           constraint: %ResourceConstraint{
-            resource_types: [
-              "http://www.w3.org/ns/person#Person",
-            ] ++ unconfidential_resource_types() ++
+            resource_types: unconfidential_resource_types() ++
               static_unconfidential_code_list_types() ++
               user_account_resource_types()
             }

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -227,31 +227,20 @@ defmodule Acl.UserGroups.Config do
           }
         ]
       },
+
       %GroupSpec{
-        name: "o-admin-on-public",
+        name: "writes-on-public",
         useage: [:write, :read_for_write],
-        access: direct_write_on_public( "admin" ),
-        graphs: [ %GraphSpec{
-          graph: "http://mu.semte.ch/graphs/public",
-          constraint: %ResourceConstraint{
-            resource_types: unconfidential_resource_types() ++
-              static_unconfidential_code_list_types() ++
-              user_account_resource_types()
-            }
-          },
-        ]
-      },
-      %GroupSpec{
-        name: "o-kanselarij-on-public",
-        useage: [:write, :read_for_write],
-        access: direct_write_on_public( "kanselarij" ),
+        access: access_by_group( "<http://data.kanselarij.vlaanderen.be/id/group/admin>
+                                 <http://data.kanselarij.vlaanderen.be/id/group/kanselarij>"),
         graphs: [ %GraphSpec{
           graph: "http://mu.semte.ch/graphs/public",
           constraint: %ResourceConstraint{
             resource_types: unconfidential_resource_types() ++
               static_unconfidential_code_list_types() ++
               user_account_resource_types() # TODO: user_account_resource_types don't belong here. Needs data-redistribution over different graphs-work.
-          } },
+            }
+          },
         ]
       },
 

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -8,13 +8,13 @@
     [
       { "name": "o-admin-roles", "variables": [] },
       { "name": "o-kanselarij-all", "variables": [] },
-      { "name": "o-admin-on-public", "variables": [] },
+      { "name": "writes-on-public", "variables": [] },
       { "name": "public", "variables": [] },
       { "name": "clean", "variables": [] }
     ],
     [
       { "name": "o-kanselarij-all", "variables": [] },
-      { "name": "o-kanselarij-on-public", "variables": [] },
+      { "name": "writes-on-public", "variables": [] },
       { "name": "public", "variables": [] },
       { "name": "clean", "variables": [] }
     ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,7 +176,7 @@ services:
       - ./config/mocklogin:/config
     logging: *default-logging
   login:
-    image: kanselarij/acmidm-login-service:1.2.1
+    image: kanselarij/acmidm-login-service:1.4.0
     environment:
       MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
       MU_APPLICATION_AUTH_CLIENT_ID: "b1c78c1e-3c88-44f4-90fa-bebc5c5dc28d"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     labels:
       - "logging=true"
   cache-warmup:
-    image: kanselarij/cache-warmup-service:1.1.0
+    image: kanselarij/cache-warmup-service:1.2.0
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
Some group configs used `access_by_role` for checking access, others `direct_write_on_public`. Since we currently don't intend to work based off of backend defined roles, `direct_write_on_public` has been removed and groupspecs using it have been refactored to use `access_by_group`. Furthermore some refactoring & cleanup.

Related PR's which need merging and a release before merging this one are:  

- [x] https://github.com/kanselarij-vlaanderen/acmidm-login-service/pull/9
- [x] https://github.com/kanselarij-vlaanderen/cache-warmup-service/pull/3
- [x] https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1301