### PR TITLE
KAS 2305 Remove session-number-service from backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ __MACOSX
 
 # Keyfiles
 *.pem
+
+# Accept data
+acc-data/

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -208,10 +208,6 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://custom-subcases/"
   end
 
-  match "/session-number/*path", @any do
-    Proxy.forward conn, path, "http://session-number/"
-  end
-
   match "/agenda-approve/*path", @any do
     Proxy.forward conn, path, "http://agenda-approve/"
   end

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -59,8 +59,6 @@ services:
     restart: "no"
   file:
     restart: "no"
-  session-number:
-    restart: "no"
   agenda-sort:
     restart: "no"
   custom-subcases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,12 +146,6 @@ services:
     restart: always
     labels:
       - "logging=true"
-  session-number:
-    image: kanselarij/session-number-service:1.3.0
-    logging: *default-logging
-    restart: always
-    labels:
-      - "logging=true"
   agenda-sort:
     image: kanselarij/agenda-sort-service:2.3.0
     logging: *default-logging


### PR DESCRIPTION
Frontend PR: https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1289

After this gets merged, service should get archived on Github. https://github.com/kanselarij-vlaanderen/session-number-service