### PR TITLE
Remove unused approvals from data model

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -48,7 +48,6 @@ defmodule Acl.UserGroups.Config do
       "http://data.vlaanderen.be/ns/besluit#Vergaderactiviteit",
       "http://data.vlaanderen.be/ns/besluitvorming#Agendering",
       "http://mu.semte.ch/vocabularies/ext/Indieningsactiviteit",
-      "http://mu.semte.ch/vocabularies/ext/Goedkeuring",
     ]
   end
 

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -71,8 +71,6 @@
                                       :inverse t
                                       :as "treatments")
             ;; Added has-many relations from subcases
-              (approval               :via      ,(s-prefix "ext:agendapuntGoedkeuring")
-                                      :as "approvals")
               (mandatee               :via      ,(s-prefix "ext:heeftBevoegdeVoorAgendapunt") ;; NOTE: used mandataris instead of agent
                                       :as "mandatees")
               (piece                  :via      ,(s-prefix "besluitvorming:geagendeerdStuk")
@@ -82,19 +80,6 @@
   :resource-base (s-url "http://themis.vlaanderen.be/id/agendapunt/")
   :features `(no-pagination-defaults include-uri)
   :on-path "agendaitems")
-
-
-  (define-resource approval ()
-  :class (s-prefix "ext:Goedkeuring")
-  :properties `((:created   :datetime ,(s-prefix "ext:aangemaakt")))
-  :has-one `((mandatee      :via ,(s-prefix "ext:goedkeuringen")
-                            :inverse t
-                            :as "mandatee")
-             (agendaitem    :via ,(s-prefix "ext:agendapuntGoedkeuring")
-                            :inverse t
-                            :as "agendaitem"))
-  :resource-base (s-url "http://themis.vlaanderen.be/id/goedkeuring/")
-  :on-path "approvals")
 
 (define-resource agenda-item-treatment ()
   :class (s-prefix "besluit:BehandelingVanAgendapunt") ; Also includes properties/relations from besluitvorming:Beslissingsactiviteit

--- a/config/resources/mandaat-domain.lisp
+++ b/config/resources/mandaat-domain.lisp
@@ -6,9 +6,7 @@
                 (:end             :datetime ,(s-prefix "mandaat:einde"))
                 (:newsletter-title :string ,(s-prefix "ext:nieuwsbriefTitel")) ; As opposed to the dct:title, this property includes the name of the mandatee
                 (:title           :string ,(s-prefix "dct:title")))
-  :has-many `((approval            :via ,(s-prefix "ext:goedkeuringen")
-                                  :as "approvals")
-             (subcase             :via ,(s-prefix "ext:heeftBevoegde")
+  :has-many `((subcase             :via ,(s-prefix "ext:heeftBevoegde")
                                   :inverse t
                                   :as "subcases")
              (publication-flow    :via ,(s-prefix "ext:heeftBevoegdeVoorPublicatie")
@@ -78,4 +76,3 @@
   :resource-base (s-url "http://themis.vlaanderen.be/id/bestuursorgaan/")
   :features '(include-uri)
   :on-path "government-bodies")
-


### PR DESCRIPTION
As discussed on chat approvals are an unused feature adding complexity to the codebase. Legacy code/data model is therefore removed.

Frontend PR: https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1312