### PR TITLE
Reduce update wait interval of mu-search to 0

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -11,7 +11,7 @@ export default [
     },
     options: {
       resourceFormat: "v0.0.1",
-      gracePeriod: 10000,
+      gracePeriod: 1000,
       ignoreFromSelf: true
     }
   },

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -2,7 +2,7 @@
   "batch_size": 128,
   "max_batches": 0,
   "number_of_threads": 4,
-  "update_wait_interval_minutes": 8,
+  "update_wait_interval_minutes": 0,
   "automatic_index_updates": true,
   "eager_indexing_groups": [
     [


### PR DESCRIPTION
By reducing the wait interval updates get (re)indexed immediately. This
is a requirement for publications to easily find new/updated
publications.

The interval has been set to 8 minutes in the past to avoid duplicate
reindexing of entries due to Yggdrasil propagations. This argument no
longer holds since the refactor of Yggdrasil where only effective
changes are inserted/deleted and trigger delta-notifications.

Tested locally and seems to work, but probably best to test thoroughly on ACC. Rollback is easy in case things go wrong.