### PR TITLE
KAS-3197 - bugfix/KAS-3197-treatments-ignore-cache

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -67,6 +67,10 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://document-versions/agendaitems/" <> id <> "/pieces/restore"
   end
 
+  match "/agendaitems/:id/treatments", @json_service do
+    Proxy.forward conn, [], "http://resource/agendaitems/" <> id <> "/treatments"
+  end
+
   get "/agendas/:agenda_id/compare/:compared_agenda_id/agenda-items", @json_service do
     Proxy.forward conn, [], "http://agenda-sort/agendas/" <> agenda_id <> "/compare/" <> compared_agenda_id <> "/agenda-items"
   end


### PR DESCRIPTION
Bug:

Yggdrasil is not sending a cache clear signal to `agendaitem/id/treatments` on "releasing decisions"
In some situations this can lead to cache never invalidating unless extra steps are done and data not showing
(f.e. when government profile checked that agenda before the decisions were released they effectively cached the result as empty, so without a cache invalidation this stays empty)

"fixed" it by ignoring cache for this specific call.

I'm guessing we need some documentation here, if the fix is accepted.
Also, when we separate the treatments and decisions, we might have to keep this in mind.
Perhaps we should do something similar to documents, where we release the pieces but not the files, not sure if this is acceptable for the business. But we could pair that with a conditional flag in frontend to check for "releasedDecisions == true".
