### PR TITLE
KAS-3481 cleanup relation with migration

### DIFF
--- a/config/migrations/20220616163000-cleanup-old-relation-confidential-piece.sparql
+++ b/config/migrations/20220616163000-cleanup-old-relation-confidential-piece.sparql
@@ -1,0 +1,14 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+
+DELETE {
+  GRAPH ?g {
+    ?document ext:vertrouwelijk ?confidential .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?document a dossier:Stuk ;
+              ext:vertrouwelijk ?confidential .
+  }
+}


### PR DESCRIPTION
Already had a cleanup in the migration relevant to the refactor of the confidential boolean to an accessLevel relation. The delete statements were executed but the data of this particular relation was still present.

Assuming that maybe `?s ?p "true/false"^^...boolean` was not accepted as a delete statement, working with variable instead for this query.