### PR TITLE
Feature/kas 3488 minister title in dropdown

### DIFF
--- a/config/migrations/20220621085337-remove-incorrect-mandatees.sparql
+++ b/config/migrations/20220621085337-remove-incorrect-mandatees.sparql
@@ -33,4 +33,16 @@ DELETE WHERE {
   	<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05d8> ?p ?o .
     ?s ?p_ <http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05d8> .
   }
+};
+DELETE WHERE {
+  GRAPH ?g {
+    <http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a056e> ?p ?o .
+    ?s ?p_ <http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a056e> .
+  }
+};
+DELETE WHERE {
+  GRAPH ?g {
+    <http://themis.vlaanderen.be/id/mandataris/6c1ff914-8472-49ed-a22b-8d01d907ff8b> ?p ?o .
+    ?s ?p_ <http://themis.vlaanderen.be/id/mandataris/6c1ff914-8472-49ed-a22b-8d01d907ff8b> .
+  }
 }

--- a/config/migrations/20220621085337-remove-incorrect-mandatees.sparql
+++ b/config/migrations/20220621085337-remove-incorrect-mandatees.sparql
@@ -1,0 +1,36 @@
+DELETE WHERE {
+  GRAPH ?g { 
+  	<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a057b> ?p ?o .
+    ?s ?p_ <http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a057b> .
+  }
+};
+DELETE WHERE {
+  GRAPH ?g { 
+  	<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0589> ?p ?o .
+    ?s ?p_ <http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0589> .
+  }
+};
+DELETE WHERE {
+  GRAPH ?g { 
+  	<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0599> ?p ?o .
+    ?s ?p_ <http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0599> .
+  }
+};
+DELETE WHERE {
+  GRAPH ?g { 
+  	<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05b9> ?p ?o .
+    ?s ?p_ <http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05b9> .
+  }
+};
+DELETE WHERE {
+  GRAPH ?g { 
+  	<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05c9> ?p ?o .
+    ?s ?p_ <http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05c9> .
+  }
+};
+DELETE WHERE {
+  GRAPH ?g { 
+  	<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05d8> ?p ?o .
+    ?s ?p_ <http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05d8> .
+  }
+}


### PR DESCRIPTION
Removes mandatees that are incorrect, in particular 5 Dewael mandatees and 3 Somers mandatees.

Mandatees are incorrect because for those periods of time Dewael and Somers were *just* Minister-president, they did not have another mandate as minister (vakrol).

See:
- https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1387
- https://github.com/kanselarij-vlaanderen/app-themis/pull/7