### PR TITLE
KAS-3489 add urgencyLevel to publication search index

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -342,6 +342,10 @@
           "http://www.w3.org/ns/adms#status",
           "http://mu.semte.ch/vocabularies/core/uuid"
         ],
+        "urgencyLevelId": [
+          "http://mu.semte.ch/vocabularies/ext/publicatie/urgentieniveau",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
         "mandateeFirstNames": [
           "http://mu.semte.ch/vocabularies/ext/heeftBevoegdeVoorPublicatie",
           "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
@@ -425,6 +429,9 @@
             "type": "keyword"
           },
           "statusId": {
+            "type": "keyword"
+          },
+          "urgencyLevelId": {
             "type": "keyword"
           },
           "mandateeFirstNames": {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3489

Backend change for this search index

Frontend consists of multiple branches
1 is related to dates, can be merged without this PR (no changes to index needed) https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1390
2 mutually exclusive branches:
1 is searching for only urgent publications, needs the index update https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1391
1 is searching for both values of urgent, need this index update but will also need migrations and code change to work. https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1392
