### PR TITLE
KAS-3515: Urgency-level 'Standaard' als default voor nieuwe publicaties

### DIFF
--- a/config/migrations/20220704081440-add-default-urgency-level.sparql
+++ b/config/migrations/20220704081440-add-default-urgency-level.sparql
@@ -1,0 +1,10 @@
+PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+
+WITH <http://mu.semte.ch/graphs/organizations/kanselarij>
+INSERT {
+  ?publicationFlow pub:urgentieniveau <http://themis.vlaanderen.be/id/concept/urgentieniveau/5a48d953-3d88-4eb6-b784-ddb3070c831d> .
+}
+WHERE {
+  ?publicationFlow a pub:Publicatieaangelegenheid .
+  FILTER NOT EXISTS { ?publicationFlow pub:urgentieniveau ?urgencyLevel . }
+}


### PR DESCRIPTION
https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1408