### PR TITLE
KAS-3525: upgrade Tika

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
     logging: *default-logging
     restart: always
   tika:
-    image: apache/tika:1.24-full
+    image: redpencil/tika:2.4.0
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
Draft because the Drone pipeline needs to be enabled before we can use the Docker image.

See: https://github.com/redpencilio/docker-tika