### PR TITLE
KAS-3549: Remove newsletter from meeting

### DIFF
--- a/config/migrations/20220817083000-remove-newsletter-from-meeting.sparql
+++ b/config/migrations/20220817083000-remove-newsletter-from-meeting.sparql
@@ -1,0 +1,16 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?graph {
+    ?newsletter ?p ?o .
+    ?s ?pp ?newsletter .
+  }
+}
+WHERE {
+  GRAPH ?graph {
+    ?meeting ext:algemeneNieuwsbrief ?newsletter .
+
+    OPTIONAL { ?newsletter ?p ?o . }
+    OPTIONAL { ?s ?pp ?newsletter . }
+  }
+}

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -196,8 +196,6 @@
                                            :as "themis-publication-activities"))
   :has-one `((agenda                    :via      ,(s-prefix "besluitvorming:behandelt");; NOTE: What is the URI of property 'behandelt'? Made up besluitvorming:behandelt
                                         :as "agenda")
-             (newsletter-info           :via      ,(s-prefix "ext:algemeneNieuwsbrief")
-                                        :as "newsletter")
               ;; (piece                    :via ,(s-prefix "dossier:genereert") ;; this relation exists in legacy data, but we do not show this in the frontend currently
               ;;                           :as "notes") ;; note: is this a hasOne or hasMany ?
              (mail-campaign             :via      ,(s-prefix "ext:heeftMailCampagnes")

--- a/config/resources/newsletter-domain.lisp
+++ b/config/resources/newsletter-domain.lisp
@@ -9,10 +9,7 @@
                 (:in-newsletter         :boolean  ,(s-prefix "ext:inNieuwsbrief"))
                 (:remark                :string   ,(s-prefix "ext:opmerking"))
                 (:modified              :datetime ,(s-prefix "ext:aangepastOp")))
-  :has-one `((meeting                   :via      ,(s-prefix "ext:algemeneNieuwsbrief")
-                                        :inverse t
-                                        :as "meeting")
-             (agenda-item-treatment     :via      ,(s-prefix "prov:generated")
+  :has-one `((agenda-item-treatment     :via      ,(s-prefix "prov:generated")
                                         :inverse t
                                         :as "agenda-item-treatment")
              (user                      :via      ,(s-prefix "ext:modifiedBy")

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -489,10 +489,6 @@
           "http://purl.org/dc/terms/subject",
           "http://www.w3.org/2004/02/skos/core#prefLabel"
         ],
-        "generalNewsletterMeetingId": [
-          "^http://mu.semte.ch/vocabularies/ext/algemeneNieuwsbrief",
-          "http://mu.semte.ch/vocabularies/core/uuid"
-        ],
         "decisions": {
           "via": [
             "^http://www.w3.org/ns/prov#generated",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
     labels:
       - "logging=true"
   agenda-approve:
-    image: kanselarij/agenda-approve-service:feature-KAS-3549-remove-newsletter-from-meeting
+    image: kanselarij/agenda-approve-service:5.3.0
     logging: *default-logging
     restart: always
     labels:
@@ -202,7 +202,7 @@ services:
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:feature-KAS-3549-remove-newsletter-from-meeting
+    image: kanselarij/yggdrasil:5.7.0
     logging: *default-logging
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
     labels:
       - "logging=true"
   agenda-approve:
-    image: kanselarij/agenda-approve-service:5.2.0
+    image: kanselarij/agenda-approve-service:feature-KAS-3549-remove-newsletter-from-meeting
     logging: *default-logging
     restart: always
     labels:
@@ -202,7 +202,7 @@ services:
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:5.6.2
+    image: kanselarij/yggdrasil:feature-KAS-3549-remove-newsletter-from-meeting
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1437

- Removes the relation between `meeting` and `newsletter-info` in resources config
- Removes meeting id property from `newsletter-info` in search config (AFAIK, re-index is not necessary since we're just removing this property and we will also remove it's single usage in the frontend PR)
- Adds a migration to remove all newsletter-info linked to meetings