### PR TITLE
KAS-3482: Search on agendaitem pieces

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -115,6 +115,10 @@
           "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
           "http://xmlns.com/foaf/0.1/familyName"
         ],
+        "pieceNames": [
+          "http://data.vlaanderen.be/ns/besluitvorming#geagendeerdStuk",
+          "http://purl.org/dc/terms/title"
+        ],
         "data": {
           "via": [
             "http://data.vlaanderen.be/ns/besluitvorming#geagendeerdStuk",
@@ -178,6 +182,11 @@
             "search_analyzer": "dutchanalyzer"
           },
           "mandateeFamilyNames": {
+            "type": "text",
+            "analyzer": "dutchanalyzer",
+            "search_analyzer": "dutchanalyzer"
+          },
+          "pieceNames": {
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"


### PR DESCRIPTION
https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1439

This allows us to filter on an agendaitem's pieces' names.