### PR TITLE
Add services and configuration to setup live mirror stack

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -327,6 +327,35 @@ defmodule Acl.UserGroups.Config do
         ]
       },
 
+      # // READ ACCESS FOR SYNC-CONSUMER SERVICE FROM OTHER STACK
+      #
+      %GroupSpec{
+        name: "sync-consumer",
+        useage: [:read],
+        access:
+        %AccessByQuery{
+          vars: [],
+          query: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+          PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+          PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+          SELECT ?thing WHERE {
+            <SESSION_ID> muAccount:account <http://services.lblod.info/diff-consumer/account>.
+            VALUES ?thing { \"let me in\" }
+          }"
+        },
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/delta-files",
+            constraint: %ResourceConstraint{
+              resource_types: [
+                "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject"
+              ]
+            }
+          }
+        ]
+      },
+
       # // CLEANUP
       #
       %GraphCleanup{

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -180,5 +180,26 @@ export default [
       gracePeriod: 15000,
       ignoreFromSelf: true
     }
-  }
+  },
+  /* Mirror sync producer */
+  ...['http://mu.semte.ch/graphs/organizations/admin',
+    'http://mu.semte.ch/graphs/organizations/intern-overheid',
+    'http://mu.semte.ch/graphs/organizations/intern-regering',
+    'http://mu.semte.ch/graphs/organizations/kanselarij',
+    'http://mu.semte.ch/graphs/organizations/minister',
+    'http://mu.semte.ch/graphs/public',
+    'http://mu.semte.ch/graphs/system/email',
+  ].map((graph) => {
+    return {
+      match: { graph: { value: graph } },
+      callback: {
+        url: 'http://delta-producer/delta',
+        method: 'POST'
+      },
+      options: {
+        resourceFormat: 'v0.0.1',
+        gracePeriod: 1000
+      }
+    };
+  })
 ];

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -29,6 +29,16 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://file/files/"
   end
 
+  ### Mirror sync producer
+
+  match "/sync/*path", %{} do
+    Proxy.forward conn, path, "http://delta-producer/"
+  end
+
+  match "/fileshare/*path", %{} do
+    Proxy.forward conn, path, "http://fileshare/download/"
+  end
+
   ### Search
 
   match "/agendaitems/search/*path", @json_service do

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -108,6 +108,12 @@ services:
     restart: "no"
   publication-report:
     restart: "no"
+  delta-producer:
+    entrypoint: "echo 'service disabled'"
+    restart: "no"
+  fileshare:
+    entrypoint: "echo 'service disabled'"
+    restart: "no"
   # kibana:
   #   image: docker.elastic.co/kibana/kibana:7.2.0
   #   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -317,3 +317,18 @@ services:
     restart: always
     labels:
       - "logging=true"
+  delta-producer:
+    image: lblod/delta-producer-json-diff-file-publisher:0.5.0
+    environment:
+      PUBLISHER_URI: "http://delta-producer-json-diff-file-publisher.services.semantic.works/me"
+      PRETTY_PRINT_DIFF_JSON: "true"
+      FILES_GRAPH: "http://mu.semte.ch/graphs/delta-files"
+      KEY: "secret-sync-key"
+    volumes:
+      - ./data/files:/share
+  fileshare:
+    image: redpencil/file-share-sync:0.0.4
+    volumes:
+      - ./data/files:/share
+    environment:
+      ALLOW_SUPER_CONSUMER: "true"


### PR DESCRIPTION
Services and configuration required to setup a live mirror stack based on the producer-consumer paradigm.

General concept:
- at the producer side all triples written to one of the configured graphs are dumped to diff files at regular intervals
- at the consumer side [a service](https://github.com/lblod/delta-consumer/tree/feature/update-configuration-api) regularly checks for new diff files and ingests those. 

The consumer identifies itself at the producer side based on a shared secret. 