### PR TITLE
KAS-3490 add migration for changing preflabel on access level

### DIFF
--- a/config/migrations/20220916160000-rename-accesslevel-confidential.sparql
+++ b/config/migrations/20220916160000-rename-accesslevel-confidential.sparql
@@ -1,0 +1,18 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+# rename "Ministerraad" > "Vertrouwelijk" in accessLevel
+
+DELETE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17> skos:prefLabel ?l .
+    }
+}
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17> skos:prefLabel "Vertrouwelijk" .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17> skos:prefLabel ?l .
+    }
+}

--- a/config/migrations/20220916160000-rename-accesslevel-confidential.sparql
+++ b/config/migrations/20220916160000-rename-accesslevel-confidential.sparql
@@ -8,7 +8,7 @@ DELETE {
 }
 INSERT {
     GRAPH <http://mu.semte.ch/graphs/public> {
-        <http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17> skos:prefLabel "Vertrouwelijk" .
+        <http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17> skos:prefLabel "Vertrouwelijk"@nl .
     }
 }
 WHERE {

--- a/config/resources/dossier-domain.lisp
+++ b/config/resources/dossier-domain.lisp
@@ -53,7 +53,7 @@
   :properties `((:short-title         :string ,(s-prefix "dct:alternative"))
                 (:title               :string ,(s-prefix "dct:title"))
                 (:is-archived         :boolean   ,(s-prefix "ext:isProcedurestapGearchiveerd"))
-                (:confidential        :boolean   ,(s-prefix "ext:vertrouwelijk"))
+                (:confidential        :boolean   ,(s-prefix "ext:vertrouwelijk")) ;; This is seen as "Beperkte toegang" in frontend
                 (:subcase-name        :string ,(s-prefix "ext:procedurestapNaam"))
                 (:created             :datetime ,(s-prefix "dct:created"))
                 (:modified            :datetime ,(s-prefix "ext:modified")))


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3490

frontend PR https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1476

- migration to change label
- added note about subcase confidential property not being fully renamed to "Beperkte toegang" to avoid confusion later