### PR TITLE
KAS-3520: government fields register

### DIFF
--- a/config/migrations/20220926091613-beleidsdomeinen-en-velden-concept-scheme-uri.sparql
+++ b/config/migrations/20220926091613-beleidsdomeinen-en-velden-concept-scheme-uri.sparql
@@ -1,0 +1,41 @@
+DELETE {
+  GRAPH ?g {
+    ?oldConceptSchemeUri ?p ?o .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?newConceptSchemeUri ?p ?o .
+  }
+}
+WHERE {
+  VALUES (?oldConceptSchemeUri ?newConceptSchemeUri) {
+    (<http://themis.vlaanderen.be/id/concept-schema/f4981a92-8639-4da4-b1e3-0e1371feaa81> <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81>)
+    (<http://themis.vlaanderen.be/id/concept-schema/0012aad8-d6e5-49e2-af94-b1bebd484d5b> <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b>)
+  }
+  GRAPH ?g {
+    ?oldConceptSchemeUri ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?oldConceptSchemeUri .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s ?p ?newConceptSchemeUri .
+  }
+}
+WHERE {
+  VALUES (?oldConceptSchemeUri ?newConceptSchemeUri) {
+    (<http://themis.vlaanderen.be/id/concept-schema/f4981a92-8639-4da4-b1e3-0e1371feaa81> <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81>)
+    (<http://themis.vlaanderen.be/id/concept-schema/0012aad8-d6e5-49e2-af94-b1bebd484d5b> <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b>)
+  }
+  GRAPH ?g {
+    ?s ?p ?oldConceptSchemeUri .
+  }
+}

--- a/config/migrations/20220926091614-beleidsdomeinen-themis-concepts.graph
+++ b/config/migrations/20220926091614-beleidsdomeinen-themis-concepts.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20220926091614-beleidsdomeinen-themis-concepts.ttl
+++ b/config/migrations/20220926091614-beleidsdomeinen-themis-concepts.ttl
@@ -1,0 +1,124 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix core: <http://kanselarij.vo.data.gift/core/> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix tl: <http://mu.semte.ch/vocabularies/typed-literals/> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "c23a60f3-ffaf-44ef-be18-ff1792117caa" ;
+  skos:prefLabel "Diensten voor het algemeen regeringsbeleid"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "true"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "d371aadd-73c5-420d-bc4e-f1eacbfaf023" ;
+  skos:prefLabel "Bestuurszaken"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "true"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "58c91fe9-8839-4653-9693-9a7df6885c06" ;
+  skos:prefLabel "Financiën en begroting"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "false"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "66d2ca3e-5bcf-405c-b704-4621004d051b" ;
+  skos:prefLabel "Buitenlands beleid, buitenlandse handel, internationale samenwerking en toerisme"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "true"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "e2ccf3f9-6b1f-4b32-9e76-501999c51788" ;
+  skos:prefLabel "Economie, wetenschap en innovatie"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "false"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "cb105245-de9e-4d32-8ef9-519b832ed4f9" ;
+  skos:prefLabel "Onderwijs en vorming"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "false"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "53af66e3-b055-4a74-9f24-03ea9def4e0c" ;
+  skos:prefLabel "Welzijn, volksgezondheid en gezin"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "false"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "82535aaf-39ec-4b31-a181-f44241a65c93" ;
+  skos:prefLabel "Cultuur, jeugd, sport en media"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "false"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "a41f29a9-7781-4419-a821-fd3bd183c7ba" ;
+  skos:prefLabel "Werk en sociale economie"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "false"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "98a3acec-51f2-4b6a-a1e1-6b6166d80d2e" ;
+  skos:prefLabel "Landbouw en visserij"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "false"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "ddc5a250-da82-4102-a47e-9f97c2ff6881" ;
+  skos:prefLabel "Leefmilieu, natuur en energie"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "true"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "be302e1b-f4d8-4212-a67d-bf992e6effcf" ;
+  skos:prefLabel "Mobiliteit en openbare werken"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "false"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "90ca98c8-efc4-4fa6-8124-51208cc353ee" ;
+  skos:prefLabel "Ruimtelijke ordening, woonbeleid en onroerend erfgoed"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "true"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "496f03b0-6582-4cfc-97b7-150a276d684f" ;
+  skos:prefLabel "Internationaal Vlaanderen"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "true"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "8aefc421-830d-4eb8-a302-6649d346414f" ;
+  skos:prefLabel "Kanselarij en Bestuur"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "true"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "5a0d6e96-061d-4d91-900d-173d138f79a4" ;
+  skos:prefLabel "Omgeving"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "false"^^tl:boolean .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> a core:Beleidsdomein, skos:Concept ;
+  mu:uuid "22a39165-e17c-4a52-963a-9fa3d097907c" ;
+  skos:prefLabel "Kanselarij, Bestuur, Buitenlandse Zaken en Justitie"@nl ;
+  skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
+  owl:deprecated "false"^^tl:boolean .

--- a/config/migrations/20220926091614-beleidsdomeinen-themis-concepts.ttl
+++ b/config/migrations/20220926091614-beleidsdomeinen-themis-concepts.ttl
@@ -6,7 +6,7 @@
 
 <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "c23a60f3-ffaf-44ef-be18-ff1792117caa" ;
-  skos:prefLabel "Diensten voor het algemeen regeringsbeleid"@nl ;
+  skos:prefLabel "Diensten Algemeen Regeringsbeleid"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "true"^^tl:boolean .
@@ -20,7 +20,7 @@
 
 <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "58c91fe9-8839-4653-9693-9a7df6885c06" ;
-  skos:prefLabel "Financiën en begroting"@nl ;
+  skos:prefLabel "Financiën en Begroting"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
@@ -34,63 +34,63 @@
 
 <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "e2ccf3f9-6b1f-4b32-9e76-501999c51788" ;
-  skos:prefLabel "Economie, wetenschap en innovatie"@nl ;
+  skos:prefLabel "Economie, Wetenschap en Innovatie"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
 <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "cb105245-de9e-4d32-8ef9-519b832ed4f9" ;
-  skos:prefLabel "Onderwijs en vorming"@nl ;
+  skos:prefLabel "Onderwijs en Vorming"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
 <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "53af66e3-b055-4a74-9f24-03ea9def4e0c" ;
-  skos:prefLabel "Welzijn, volksgezondheid en gezin"@nl ;
+  skos:prefLabel "Welzijn, Volksgezondheid en Gezin"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
 <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "82535aaf-39ec-4b31-a181-f44241a65c93" ;
-  skos:prefLabel "Cultuur, jeugd, sport en media"@nl ;
+  skos:prefLabel "Cultuur, Jeugd, Sport en Media"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
 <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "a41f29a9-7781-4419-a821-fd3bd183c7ba" ;
-  skos:prefLabel "Werk en sociale economie"@nl ;
+  skos:prefLabel "Werk & sociale economie"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
 <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "98a3acec-51f2-4b6a-a1e1-6b6166d80d2e" ;
-  skos:prefLabel "Landbouw en visserij"@nl ;
+  skos:prefLabel "Landbouw en Visserij"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
 <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "ddc5a250-da82-4102-a47e-9f97c2ff6881" ;
-  skos:prefLabel "Leefmilieu, natuur en energie"@nl ;
+  skos:prefLabel "Leefmilieu, Natuur en Energie"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "true"^^tl:boolean .
 
 <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "be302e1b-f4d8-4212-a67d-bf992e6effcf" ;
-  skos:prefLabel "Mobiliteit en openbare werken"@nl ;
+  skos:prefLabel "Mobiliteit en Openbare Werken"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
 <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "90ca98c8-efc4-4fa6-8124-51208cc353ee" ;
-  skos:prefLabel "Ruimtelijke ordening, woonbeleid en onroerend erfgoed"@nl ;
+  skos:prefLabel "Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "true"^^tl:boolean .

--- a/config/migrations/20220926091614-beleidsdomeinen-themis-concepts.ttl
+++ b/config/migrations/20220926091614-beleidsdomeinen-themis-concepts.ttl
@@ -1,122 +1,122 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix core: <http://kanselarij.vo.data.gift/core/> .
 @prefix mu: <http://mu.semte.ch/vocabularies/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix tl: <http://mu.semte.ch/vocabularies/typed-literals/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "c23a60f3-ffaf-44ef-be18-ff1792117caa" ;
   skos:prefLabel "Diensten voor het algemeen regeringsbeleid"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "true"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "d371aadd-73c5-420d-bc4e-f1eacbfaf023" ;
   skos:prefLabel "Bestuurszaken"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "true"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "58c91fe9-8839-4653-9693-9a7df6885c06" ;
   skos:prefLabel "Financiën en begroting"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "66d2ca3e-5bcf-405c-b704-4621004d051b" ;
   skos:prefLabel "Buitenlands beleid, buitenlandse handel, internationale samenwerking en toerisme"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "true"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "e2ccf3f9-6b1f-4b32-9e76-501999c51788" ;
   skos:prefLabel "Economie, wetenschap en innovatie"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "cb105245-de9e-4d32-8ef9-519b832ed4f9" ;
   skos:prefLabel "Onderwijs en vorming"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "53af66e3-b055-4a74-9f24-03ea9def4e0c" ;
   skos:prefLabel "Welzijn, volksgezondheid en gezin"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "82535aaf-39ec-4b31-a181-f44241a65c93" ;
   skos:prefLabel "Cultuur, jeugd, sport en media"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "a41f29a9-7781-4419-a821-fd3bd183c7ba" ;
   skos:prefLabel "Werk en sociale economie"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "98a3acec-51f2-4b6a-a1e1-6b6166d80d2e" ;
   skos:prefLabel "Landbouw en visserij"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "ddc5a250-da82-4102-a47e-9f97c2ff6881" ;
   skos:prefLabel "Leefmilieu, natuur en energie"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "true"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "be302e1b-f4d8-4212-a67d-bf992e6effcf" ;
   skos:prefLabel "Mobiliteit en openbare werken"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "90ca98c8-efc4-4fa6-8124-51208cc353ee" ;
   skos:prefLabel "Ruimtelijke ordening, woonbeleid en onroerend erfgoed"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "true"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "496f03b0-6582-4cfc-97b7-150a276d684f" ;
   skos:prefLabel "Internationaal Vlaanderen"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "true"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "8aefc421-830d-4eb8-a302-6649d346414f" ;
   skos:prefLabel "Kanselarij en Bestuur"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "true"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "5a0d6e96-061d-4d91-900d-173d138f79a4" ;
   skos:prefLabel "Omgeving"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;
   owl:deprecated "false"^^tl:boolean .
 
-<http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> a core:Beleidsdomein, skos:Concept ;
+<http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> a ext:Beleidsdomein, skos:Concept ;
   mu:uuid "22a39165-e17c-4a52-963a-9fa3d097907c" ;
   skos:prefLabel "Kanselarij, Bestuur, Buitenlandse Zaken en Justitie"@nl ;
   skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> ;

--- a/config/migrations/20220926091615-beleidsdomeinen-themis-concepts-migratie.sparql
+++ b/config/migrations/20220926091615-beleidsdomeinen-themis-concepts-migratie.sparql
@@ -1,0 +1,74 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH ?g {
+    ?oldGovernmentDomain ?p ?o .
+    ?oldGovernmentDomain skos:prefLabel ?oldLabel .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?newGovernmentDomain ?p ?o .
+  }
+}
+WHERE {
+  VALUES (?oldGovernmentDomain ?newGovernmentDomain) {
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/diensten-algemeen-regeringsbeleid> <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/bestuurszaken> <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/leefmilieu-natuur-en-energie> <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/ruimtelijke-ordening-woonbeleid-en-onroerend-erfgoed> <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/internationaal-vlaanderen> <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/kanselarij-en-bestuur> <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c>)
+  }
+  GRAPH ?g {
+    ?oldGovernmentDomain ?p ?o .
+    ?oldGovernmentDomain skos:prefLabel ?oldLabel .
+    FILTER (?p != skos:prefLabel)
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?oldGovernmentDomain .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s ?p ?newGovernmentDomain .
+  }
+}
+WHERE {
+  VALUES (?oldGovernmentDomain ?newGovernmentDomain) {
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/diensten-algemeen-regeringsbeleid> <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/bestuurszaken> <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/leefmilieu-natuur-en-energie> <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/ruimtelijke-ordening-woonbeleid-en-onroerend-erfgoed> <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/internationaal-vlaanderen> <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/kanselarij-en-bestuur> <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4>)
+    (<http://kanselarij.vo.data.gift/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c>)
+  }
+  GRAPH ?g {
+    ?s ?p ?oldGovernmentDomain .
+  }
+}

--- a/config/migrations/20220926091615-beleidsdomeinen-themis-concepts-migratie.sparql
+++ b/config/migrations/20220926091615-beleidsdomeinen-themis-concepts-migratie.sparql
@@ -1,4 +1,5 @@
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 DELETE {
   GRAPH ?g {
@@ -34,6 +35,7 @@ WHERE {
     ?oldGovernmentDomain ?p ?o .
     ?oldGovernmentDomain skos:prefLabel ?oldLabel .
     FILTER (?p != skos:prefLabel)
+    FILTER (?p != rdf:type)
   }
 }
 

--- a/config/migrations/20220926140002-beleidsvelden-themis-concepts.graph
+++ b/config/migrations/20220926140002-beleidsvelden-themis-concepts.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20220926140002-beleidsvelden-themis-concepts.ttl
+++ b/config/migrations/20220926140002-beleidsvelden-themis-concepts.ttl
@@ -1,6947 +1,6947 @@
-@prefix core: <http://kanselarij.vo.data.gift/core/> .
 @prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
 @prefix mu: <http://mu.semte.ch/vocabularies/core/> .
 @prefix schema: <http://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/01f64f4e-d435-4f98-8260-7e1843bf1555> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/01f64f4e-d435-4f98-8260-7e1843bf1555> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "01f64f4e-d435-4f98-8260-7e1843bf1555" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/08249005-75e6-4791-ac7f-dbbb3a4d79c4> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/08249005-75e6-4791-ac7f-dbbb3a4d79c4> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "08249005-75e6-4791-ac7f-dbbb3a4d79c4" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Opgroeien"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/0db685d1-811f-49f9-a6fe-348aab08bba4> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/0db685d1-811f-49f9-a6fe-348aab08bba4> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "0db685d1-811f-49f9-a6fe-348aab08bba4" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlands beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/0f693798-541d-49ee-b705-4643661402a2> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/0f693798-541d-49ee-b705-4643661402a2> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "0f693798-541d-49ee-b705-4643661402a2" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Vlaamse rand"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/106408c9-ec8e-42cf-9e8e-6a8e7ef537b1> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/106408c9-ec8e-42cf-9e8e-6a8e7ef537b1> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "106408c9-ec8e-42cf-9e8e-6a8e7ef537b1" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschapscommunicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/10d5f8a5-3dfe-4661-b6a2-c2ca98f819a3> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/10d5f8a5-3dfe-4661-b6a2-c2ca98f819a3> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "10d5f8a5-3dfe-4661-b6a2-c2ca98f819a3" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financiële operaties"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/114e5c23-e495-41b7-995c-bc390b5234a0> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/114e5c23-e495-41b7-995c-bc390b5234a0> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "114e5c23-e495-41b7-995c-bc390b5234a0" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/13842fbc-441c-46ca-a58d-f78a64eb8a93> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/13842fbc-441c-46ca-a58d-f78a64eb8a93> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "13842fbc-441c-46ca-a58d-f78a64eb8a93" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/148a2622-b159-4bf7-b6f2-0ec8a5ce2194> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/148a2622-b159-4bf7-b6f2-0ec8a5ce2194> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "148a2622-b159-4bf7-b6f2-0ec8a5ce2194" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/19c1626d-1172-48f9-81d7-368015eb3489> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/19c1626d-1172-48f9-81d7-368015eb3489> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "19c1626d-1172-48f9-81d7-368015eb3489" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugd"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 9 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Digitalisering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/2731fdbe-592b-414c-8675-22a7b9d7b3bc> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/2731fdbe-592b-414c-8675-22a7b9d7b3bc> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "2731fdbe-592b-414c-8675-22a7b9d7b3bc" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Zorginfrastructuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/2b0103aa-a3e8-4718-80f8-8de405966c57> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/2b0103aa-a3e8-4718-80f8-8de405966c57> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "2b0103aa-a3e8-4718-80f8-8de405966c57" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wonen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/32c9b7d9-6fe5-4e68-bd4f-0f895fadeb4c> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/32c9b7d9-6fe5-4e68-bd4f-0f895fadeb4c> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "32c9b7d9-6fe5-4e68-bd4f-0f895fadeb4c" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 8 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Rampenschade"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/35d0740c-2754-4ca3-a334-936401383bcf> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/35d0740c-2754-4ca3-a334-936401383bcf> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "35d0740c-2754-4ca3-a334-936401383bcf" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 13 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/3ada201d-68dd-41a3-b0da-5a8ef27de879> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/3ada201d-68dd-41a3-b0da-5a8ef27de879> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "3ada201d-68dd-41a3-b0da-5a8ef27de879" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/43b8de2e-61f9-4cf8-a018-9f3cc27f4103> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/43b8de2e-61f9-4cf8-a018-9f3cc27f4103> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "43b8de2e-61f9-4cf8-a018-9f3cc27f4103" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Dierenwelzijn"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/4cd5d9d1-099b-437e-be1a-99c069469fcb> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/4cd5d9d1-099b-437e-be1a-99c069469fcb> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "4cd5d9d1-099b-437e-be1a-99c069469fcb" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale bescherming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/4d73b772-ccfa-4bd8-bd45-6722b1972a1a> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/4d73b772-ccfa-4bd8-bd45-6722b1972a1a> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "4d73b772-ccfa-4bd8-bd45-6722b1972a1a" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 10 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Bestuursrechtspraak"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/4fbef468-55dd-4191-96bd-e0ac9e28aa91> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/4fbef468-55dd-4191-96bd-e0ac9e28aa91> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "4fbef468-55dd-4191-96bd-e0ac9e28aa91" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/52e877e2-d342-4b0c-9835-74368a296d6c> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/52e877e2-d342-4b0c-9835-74368a296d6c> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "52e877e2-d342-4b0c-9835-74368a296d6c" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ontwikkelingssamenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/581845a0-0a25-4e43-89d6-7863572aeb6c> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/581845a0-0a25-4e43-89d6-7863572aeb6c> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "581845a0-0a25-4e43-89d6-7863572aeb6c" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/59e231ce-97d2-4576-a152-c2807eefa5b6> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/59e231ce-97d2-4576-a152-c2807eefa5b6> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "59e231ce-97d2-4576-a152-c2807eefa5b6" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 12 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Interne dienstverlening Vlaamse overheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/5a9c8b50-1d07-4bcb-9dd8-f1d041437a46> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/5a9c8b50-1d07-4bcb-9dd8-f1d041437a46> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "5a9c8b50-1d07-4bcb-9dd8-f1d041437a46" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/5de93340-ce1a-4886-8425-6c80bbe0351b> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/5de93340-ce1a-4886-8425-6c80bbe0351b> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "5de93340-ce1a-4886-8425-6c80bbe0351b" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623cc5cc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623cc5cc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623cc5cc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d0fe6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d0fe6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d0fe6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Communicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d1a7c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d1a7c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d1a7c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Interne audit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d26c0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d26c0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d26c0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Geografische informatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d31c4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d31c4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d31c4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personeels- en organisatieontwikkeling"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d3c82-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d3c82-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d3c82-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "ICT"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d484e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d484e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d484e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Facilitaire dienstverlening en vastgoedbeheer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d537a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d537a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d537a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Binnenlandse aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d5e4c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d5e4c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d5e4c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Inburgeringsbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d693c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d693c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d693c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d7576-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d7576-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d7576-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financieel en waarborgbeheer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d803e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d803e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d803e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgetcontrolling"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d8c64-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d8c64-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d8c64-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Algemene boekhouding"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623d984e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623d984e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623d984e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623da32a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623da32a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623da32a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623dadac-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623dadac-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623dadac-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationale samenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623db82e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623db82e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623db82e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623dc36e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623dc36e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623dc36e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623dce0e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623dce0e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623dce0e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fundamenteel onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623dd8cc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623dd8cc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623dd8cc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Strategisch en beleidsgericht onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623de4a2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623de4a2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623de4a2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Technologische innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623def92-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623def92-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623def92-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Popularisering van de wetenschap"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623dfaaa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623dfaaa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623dfaaa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e0554-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e0554-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e0554-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e10a8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e10a8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e10a8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Levenslang leren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e1b34-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e1b34-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e1b34-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning scholen, leerlingen en studenten"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e2746-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e2746-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e2746-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheidszorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e329a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e329a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e329a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Algemeen welzijnswerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e3eb6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e3eb6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e3eb6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jongeren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e491a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e491a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e491a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ouderen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e5392-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e5392-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e5392-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kinderen en gezinnen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e5e64-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e5e64-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e5e64-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale en maatschappelijke integratie voor bijzondere doelgroepen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e68fa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e68fa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e68fa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Cultureel erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e73ae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e73ae-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e73ae-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele kunsten"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e7e3a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e7e3a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e7e3a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugdwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e8894-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e8894-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e8894-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociaal-cultureel volwassenenwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e92ee-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e92ee-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e92ee-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623e9d5c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623e9d5c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623e9d5c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623ea950-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623ea950-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623ea950-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werkgelegenheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623eb40e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623eb40e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623eb40e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele vorming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623ebee0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623ebee0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623ebee0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623ec836-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623ec836-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623ec836-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623ed222-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623ed222-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623ed222-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623edc68-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623edc68-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623edc68-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Leefmilieu"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623ee6f4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623ee6f4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623ee6f4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterbeheer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623ef1b2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623ef1b2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623ef1b2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landinrichting en nutriëntenbeheer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623efc20-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623efc20-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623efc20-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Natuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f0648-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f0648-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f0648-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Plattelandsbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f1066-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f1066-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f1066-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f1b7e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f1b7e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f1b7e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Natuurlijke rijkdommen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f2844-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f2844-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f2844-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f3320-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f3320-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f3320-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f3d7a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f3d7a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f3d7a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f491e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f491e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f491e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f6d90-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f6d90-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f6d90-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Verkeersveiligheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f7812-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f7812-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f7812-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ruimtelijke ordening"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f8258-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f8258-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f8258-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Woonbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f8cd0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f8cd0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f8cd0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623f984c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623f984c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623f984c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623fa2a6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623fa2a6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623fa2a6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Communicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623facec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623facec-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623facec-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Interne audit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623fb7e6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623fb7e6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623fb7e6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Geografische informatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623fc222-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623fc222-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623fc222-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personeels- en organisatieontwikkeling"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623fccf4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623fccf4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623fccf4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "ICT"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623fd712-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623fd712-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623fd712-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Facilitaire dienstverlening en vastgoedbeheer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623fe338-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623fe338-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623fe338-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Binnenlandse aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623fed7e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623fed7e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623fed7e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Inburgeringsbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/623ff7e2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/623ff7e2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "623ff7e2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240026e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240026e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240026e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financieel en waarborgbeheer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62400eda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62400eda-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62400eda-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgetcontrolling"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62401952-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62401952-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62401952-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Algemene boekhouding"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624023ac-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624023ac-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624023ac-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240302c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240302c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240302c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62403aa4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62403aa4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62403aa4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationale samenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624044e0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624044e0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624044e0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62404f44-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62404f44-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62404f44-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624059e4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624059e4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624059e4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fundamenteel onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62406470-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62406470-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62406470-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Strategisch en beleidsgericht onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62406ec0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62406ec0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62406ec0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Technologische innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624079c4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624079c4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624079c4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Popularisering van de wetenschap"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240850e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240850e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240850e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62408fcc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62408fcc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62408fcc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62409a44-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62409a44-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62409a44-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Levenslang leren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240a520-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240a520-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240a520-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning scholen, leerlingen en studenten"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240b0c4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240b0c4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240b0c4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheidszorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240baf6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240baf6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240baf6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Algemeen welzijnswerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240c708-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240c708-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240c708-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jongeren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240d31a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240d31a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240d31a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ouderen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240dc8e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240dc8e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240dc8e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kinderen en gezinnen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240e684-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240e684-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240e684-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale en maatschappelijke integratie voor bijzondere doelgroepen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240f106-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240f106-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240f106-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Cultureel erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6240fb60-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6240fb60-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6240fb60-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele kunsten"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62410588-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62410588-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62410588-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugdwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62410fce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62410fce-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62410fce-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociaal-cultureel volwassenenwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62411bae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62411bae-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62411bae-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624125e0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624125e0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624125e0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62412fea-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62412fea-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62412fea-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werkgelegenheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62413a9e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62413a9e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62413a9e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele vorming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62414656-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62414656-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62414656-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6241518c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6241518c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6241518c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62415aec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62415aec-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62415aec-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62416500-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62416500-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62416500-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Leefmilieu"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62416e42-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62416e42-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62416e42-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterbeheer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62417798-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62417798-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62417798-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landinrichting en nutriëntenbeheer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62418116-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62418116-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62418116-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Natuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62418abc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62418abc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62418abc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Plattelandsbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624194bc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624194bc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624194bc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62419ef8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62419ef8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62419ef8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Natuurlijke rijkdommen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6241a97a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6241a97a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6241a97a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6241b438-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6241b438-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6241b438-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6241be92-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6241be92-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6241be92-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6241c86a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6241c86a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6241c86a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6241d7b0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6241d7b0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6241d7b0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Verkeersveiligheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6241e458-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6241e458-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6241e458-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ruimtelijke ordening"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6241ef16-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6241ef16-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6241ef16-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Woonbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6241f95c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6241f95c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6241f95c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2006-08-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624203fc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624203fc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624203fc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62420e06-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62420e06-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62420e06-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning beleidsdomeinoverschrijdende thema's"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624217f2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624217f2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624217f2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gelijke kansen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242222e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242222e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242222e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Brussel"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62422da0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62422da0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62422da0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624237aa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624237aa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624237aa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Interne audit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62424204-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62424204-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62424204-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Geografische informatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62424bf0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62424bf0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62424bf0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624256d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624256d6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624256d6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "ICT"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242611c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242611c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242611c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Binnenland"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624264fe-0e06-48c1-9e97-eeb4089f5971> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624264fe-0e06-48c1-9e97-eeb4089f5971> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624264fe-0e06-48c1-9e97-eeb4089f5971" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Brussel"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62426dba-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62426dba-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62426dba-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Stedenbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624278be-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624278be-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624278be-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Inburgering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62428444-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62428444-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62428444-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personeel en organisatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62428e8a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62428e8a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62428e8a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62429880-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62429880-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62429880-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242a384-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242a384-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242a384-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgettair beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242adb6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242adb6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242adb6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242b7e8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242b7e8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242b7e8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242c29c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242c29c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242c29c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationale samenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242cd5a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242cd5a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242cd5a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242d75a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242d75a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242d75a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242e1be-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242e1be-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242e1be-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242ed30-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242ed30-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242ed30-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6242f7f8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6242f7f8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6242f7f8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschapscommunicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624301ee-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624301ee-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624301ee-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62430c20-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62430c20-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62430c20-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624316fc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624316fc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624316fc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243225a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243225a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243225a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62432c5a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62432c5a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62432c5a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beleidsthema's onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62433650-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62433650-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62433650-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Welzijnszorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243414a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243414a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243414a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62434bd6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62434bd6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62434bd6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jongeren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624355d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624355d6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624355d6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kinderen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243603a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243603a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243603a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personen met een beperking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62436a76-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62436a76-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62436a76-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale bescherming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62437566-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62437566-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62437566-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Zorginfrastructuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62437f84-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62437f84-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62437f84-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62438a56-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62438a56-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62438a56-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624394f6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624394f6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624394f6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugdbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62439eec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62439eec-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62439eec-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243a914-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243a914-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243a914-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243b5c6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243b5c6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243b5c6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243c016-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243c016-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243c016-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werkgelegenheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243ca3e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243ca3e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243ca3e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele vorming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243d47a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243d47a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243d47a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243dff6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243dff6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243dff6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243ea28-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243ea28-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243ea28-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243f342-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243f342-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243f342-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6243fd6a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6243fd6a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6243fd6a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Leefmilieu en natuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624406de-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624406de-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624406de-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244103e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244103e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244103e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624419bc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624419bc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624419bc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244234e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244234e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244234e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62442cc2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62442cc2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62442cc2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624436d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624436d6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624436d6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Verkeersbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62444266-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62444266-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62444266-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ruimtelijke ordening"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62444edc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62444edc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62444edc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Woonbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62445a4e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62445a4e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62445a4e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2013-12-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2006-08-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244639a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244639a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244639a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62446d04-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62446d04-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62446d04-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning beleidsdomeinoverschrijdende thema's"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244768c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244768c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244768c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gelijke kansen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62447fec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62447fec-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62447fec-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Brussel"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624488fc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624488fc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624488fc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62449216-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62449216-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62449216-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Audit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62449bd0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62449bd0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62449bd0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Geografische informatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244a4d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244a4d6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244a4d6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244ae2c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244ae2c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244ae2c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "ICT"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244b82c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244b82c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244b82c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Binnenland"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244c1be-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244c1be-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244c1be-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Stedenbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244caf6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244caf6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244caf6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Inburgering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244d53c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244d53c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244d53c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personeel en organisatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244de7e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244de7e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244de7e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244e8a6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244e8a6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244e8a6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244f24c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244f24c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244f24c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgettair beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6244fb8e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6244fb8e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6244fb8e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62450494-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62450494-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62450494-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62450e1c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62450e1c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62450e1c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationale samenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624517fe-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624517fe-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624517fe-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624521f4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624521f4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624521f4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62452c3a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62452c3a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62452c3a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245370c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245370c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245370c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62454260-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62454260-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62454260-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschapscommunicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62454cba-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62454cba-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62454cba-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624555e8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624555e8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624555e8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62455f2a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62455f2a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62455f2a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62456984-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62456984-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62456984-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624572a8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624572a8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624572a8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beleidsthema's onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62457be0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62457be0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62457be0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Welzijnszorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624585cc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624585cc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624585cc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62458f0e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62458f0e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62458f0e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jongeren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62459850-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62459850-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62459850-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kinderen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245a174-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245a174-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245a174-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personen met een beperking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245ad72-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245ad72-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245ad72-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale bescherming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245b6a0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245b6a0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245b6a0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Zorginfrastructuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245c000-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245c000-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245c000-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245c938-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245c938-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245c938-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245d284-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245d284-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245d284-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugdbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245dbbc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245dbbc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245dbbc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245e4b8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245e4b8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245e4b8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245edd2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245edd2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245edd2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6245f89a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6245f89a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6245f89a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werkgelegenheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624601e6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624601e6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624601e6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele vorming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62460b0a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62460b0a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62460b0a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246147e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246147e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246147e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62461e38-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62461e38-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62461e38-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246275c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246275c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246275c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624630bc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624630bc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624630bc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Leefmilieu en natuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624639a4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624639a4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624639a4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624642be-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624642be-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624642be-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62464c64-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62464c64-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62464c64-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62465588-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62465588-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62465588-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62465ec0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62465ec0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62465ec0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624667d0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624667d0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624667d0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Verkeersbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246711c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246711c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246711c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ruimtelijke ordening"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62467a4a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62467a4a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62467a4a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Woonbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624692b4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624692b4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624692b4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2014-07-24T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-01-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62469c5a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62469c5a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62469c5a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246a628-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246a628-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246a628-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning beleidsdomeinoverschrijdende thema's"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246b05a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246b05a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246b05a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gelijke kansen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246baa0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246baa0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246baa0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Brussel"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246c554-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246c554-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246c554-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246cf68-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246cf68-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246cf68-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Audit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246d936-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246d936-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246d936-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Geografische informatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246e386-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246e386-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246e386-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246ee9e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246ee9e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246ee9e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "ICT"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6246f808-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6246f808-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6246f808-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Binnenland"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62470136-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62470136-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62470136-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Stedenbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62470ac8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62470ac8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62470ac8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Inburgering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624713ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624713ce-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624713ce-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personeel en organisatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62471cca-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62471cca-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62471cca-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247274c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247274c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247274c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62473232-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62473232-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62473232-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgettair beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62473c6e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62473c6e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62473c6e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247465a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247465a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247465a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247503c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247503c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247503c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationale samenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62475b04-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62475b04-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62475b04-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624765c2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624765c2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624765c2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62476fc2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62476fc2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62476fc2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247799a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247799a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247799a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247850c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247850c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247850c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschapscommunicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624791aa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624791aa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624791aa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62479cae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62479cae-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62479cae-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247a6fe-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247a6fe-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247a6fe-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247b14e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247b14e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247b14e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247bb58-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247bb58-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247bb58-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beleidsthema's onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247c6de-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247c6de-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247c6de-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Welzijnszorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247d138-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247d138-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247d138-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247dafc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247dafc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247dafc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jongeren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247e4fc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247e4fc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247e4fc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kinderen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247ef10-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247ef10-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247ef10-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personen met een beperking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6247f9ec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6247f9ec-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6247f9ec-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale bescherming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248040a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248040a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248040a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Zorginfrastructuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62480e46-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62480e46-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62480e46-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62481846-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62481846-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62481846-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62482318-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62482318-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62482318-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugdbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62482d4a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62482d4a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62482d4a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62483790-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62483790-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62483790-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248421c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248421c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248421c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62484c30-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62484c30-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62484c30-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werkgelegenheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248564e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248564e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248564e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele vorming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624861e8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624861e8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624861e8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62486c4c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62486c4c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62486c4c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62487728-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62487728-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62487728-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62488132-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62488132-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62488132-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62488c18-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62488c18-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62488c18-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Leefmilieu en natuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624896ea-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624896ea-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624896ea-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248a180-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248a180-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248a180-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Dierenwelzijn"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248aa9a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248aa9a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248aa9a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248b3fa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248b3fa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248b3fa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248bdc8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248bdc8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248bdc8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248c6ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248c6ce-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248c6ce-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248cfe8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248cfe8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248cfe8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Verkeersbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248d8f8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248d8f8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248d8f8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ruimtelijke ordening"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248e258-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248e258-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248e258-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Woonbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248eec4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248eec4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248eec4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2015-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2014-07-25T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6248f9e6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6248f9e6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6248f9e6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249042c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249042c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249042c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning organisatiegerichte en beleidsdomeinoverschrijdende thema's"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62490ecc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62490ecc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62490ecc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gelijke kansen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624918cc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624918cc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624918cc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Brussel"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624922d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624922d6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624922d6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62492e8e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62492e8e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62492e8e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Audit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249397e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249397e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249397e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Rampenschade"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249434c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249434c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249434c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 8 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Informatiemanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62494ce8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62494ce8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62494ce8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 9 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249576a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249576a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249576a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 10 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "ICT"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624962c8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624962c8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624962c8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 11 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1binnenland"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62496c0a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62496c0a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62496c0a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 12 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1stedenbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249756a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249756a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249756a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 13 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1integratie en inburgering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62497eac-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62497eac-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62497eac-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 14 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1personeel en organisatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62498906-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62498906-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62498906-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249923e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249923e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249923e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62499b3a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62499b3a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62499b3a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgettair beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249a4a4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249a4a4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249a4a4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249ae04-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249ae04-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249ae04-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249b78c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249b78c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249b78c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationale samenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249c1aa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249c1aa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249c1aa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249cc54-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249cc54-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249cc54-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249d636-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249d636-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249d636-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249e04a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249e04a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249e04a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249ea54-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249ea54-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249ea54-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschapscommunicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249f4b8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249f4b8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249f4b8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6249ffda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6249ffda-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6249ffda-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a09a8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a09a8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a09a8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a17fe-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a17fe-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a17fe-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a2208-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a2208-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a2208-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beleidsthema's onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a2c30-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a2c30-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a2c30-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Welzijnszorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a3644-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a3644-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a3644-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a408a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a408a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a408a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jongeren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a4a8a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a4a8a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a4a8a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kinderen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a5430-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a5430-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a5430-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personen met een beperking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a5e58-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a5e58-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a5e58-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale bescherming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a6902-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a6902-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a6902-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Zorginfrastructuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a7348-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a7348-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a7348-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a7d66-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a7d66-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a7d66-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a87de-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a87de-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a87de-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugdbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a9378-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a9378-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a9378-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624a9db4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624a9db4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624a9db4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624aa70a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624aa70a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624aa70a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ab1aa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ab1aa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ab1aa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werkgelegenheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624abae2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624abae2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624abae2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele vorming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ac41a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ac41a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ac41a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624acd20-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624acd20-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624acd20-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ad630-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ad630-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ad630-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624adf68-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624adf68-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624adf68-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ae88c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ae88c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ae88c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Leefmilieu en natuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624af19c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624af19c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624af19c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624afda4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624afda4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624afda4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Dierenwelzijn"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b0844-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b0844-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b0844-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b115e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b115e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b115e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b1ad2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b1ad2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b1ad2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b23ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b23ce-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b23ce-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b2e1e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b2e1e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b2e1e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Verkeersbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b37ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b37ce-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b37ce-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ruimtelijke ordening"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b42fa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b42fa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b42fa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Woonbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b4d22-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b4d22-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b4d22-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
-    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-01-29T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2015-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b57d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b57d6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b57d6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b61b8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b61b8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b61b8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning organisatiegerichte en beleidsdomeinoverschrijdende thema's"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b6bcc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b6bcc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b6bcc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gelijke kansen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b7612-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b7612-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b7612-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Brussel"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b8008-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b8008-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b8008-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b8a44-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b8a44-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b8a44-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Audit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b9462-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b9462-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b9462-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Rampenschade"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624b9f20-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624b9f20-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624b9f20-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 8 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Informatiemanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ba902-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ba902-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ba902-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 9 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624bb30c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624bb30c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624bb30c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 10 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "ICT"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624bbcda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624bbcda-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624bbcda-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 11 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1binnenland"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624bc720-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624bc720-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624bc720-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 12 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1stedenbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624bd22e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624bd22e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624bd22e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 13 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1integratie en inburgering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624bdcc4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624bdcc4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624bdcc4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 14 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1personeel en organisatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624be5ac-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624be5ac-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624be5ac-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624bef34-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624bef34-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624bef34-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624bf858-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624bf858-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624bf858-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgettair beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c0186-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c0186-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c0186-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlandse en Europese aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c0ab4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c0ab4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c0ab4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ontwikkelingssamenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c1414-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c1414-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c1414-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c1d2e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c1d2e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c1d2e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c2634-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c2634-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c2634-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c3246-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c3246-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c3246-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c3da4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c3da4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c3da4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c4916-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c4916-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c4916-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschapscommunicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c5384-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c5384-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c5384-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c5c76-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c5c76-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c5c76-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c65f4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c65f4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c65f4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c7148-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c7148-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c7148-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c7b20-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c7b20-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c7b20-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beleidsthema's onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c85b6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c85b6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c85b6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Welzijnszorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c9088-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c9088-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c9088-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624c9aba-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624c9aba-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624c9aba-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jongeren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ca4d8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ca4d8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ca4d8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kinderen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624caf3c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624caf3c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624caf3c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personen met een beperking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624cb914-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624cb914-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624cb914-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale bescherming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624cc364-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624cc364-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624cc364-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Zorginfrastructuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ccd5a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ccd5a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ccd5a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624cd840-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624cd840-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624cd840-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ce376-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ce376-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ce376-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugdbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ceccc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ceccc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ceccc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624cf622-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624cf622-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624cf622-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624cffaa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624cffaa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624cffaa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d0bda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d0bda-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d0bda-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werkgelegenheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d1616-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d1616-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d1616-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele vorming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d1fee-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d1fee-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d1fee-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d2ab6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d2ab6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d2ab6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d36be-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d36be-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d36be-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d40dc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d40dc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d40dc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d4a46-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d4a46-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d4a46-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Leefmilieu en natuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d543c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d543c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d543c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d5e3c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d5e3c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d5e3c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Dierenwelzijn"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d6864-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d6864-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d6864-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d732c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d732c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d732c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d7e1c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d7e1c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d7e1c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d88d0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d88d0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d88d0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d91c2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d91c2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d91c2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Verkeersbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624d9b72-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624d9b72-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624d9b72-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ruimtelijke ordening"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624db382-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624db382-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624db382-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Woonbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624dbd96-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624dbd96-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624dbd96-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2016-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-01-30T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624dc836-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624dc836-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624dc836-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624dd236-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624dd236-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624dd236-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning organisatiegerichte en beleidsdomeinoverschrijdende thema's"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ddc2c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ddc2c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ddc2c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gelijke kansen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624de794-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624de794-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624de794-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Brussel"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624df27a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624df27a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624df27a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624dfd88-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624dfd88-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624dfd88-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Audit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e06ca-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e06ca-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e06ca-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Rampenschade"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e10fc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e10fc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e10fc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 8 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Informatiemanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e1a02-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e1a02-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e1a02-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 9 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e231c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e231c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e231c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 10 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "ICT"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e2c22-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e2c22-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e2c22-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 11 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1binnenland"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e35c8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e35c8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e35c8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 12 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1stedenbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e405e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e405e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e405e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 13 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1integratie en inburgering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e4964-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e4964-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e4964-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 14 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1personeel en organisatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e52b0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e52b0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e52b0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e5c10-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e5c10-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e5c10-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e6552-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e6552-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e6552-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgettair beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e6e8a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e6e8a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e6e8a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlandse en Europese aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e77ae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e77ae-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e77ae-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ontwikkelingssamenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e8104-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e8104-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e8104-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e8afa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e8afa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e8afa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e940a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e940a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e940a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624e9d2e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624e9d2e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624e9d2e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ea666-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ea666-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ea666-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624eb034-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624eb034-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624eb034-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschapscommunicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624eb980-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624eb980-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624eb980-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ec2ae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ec2ae-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ec2ae-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ecde4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ecde4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ecde4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ed8ca-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ed8ca-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ed8ca-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ee482-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ee482-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ee482-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beleidsthema's onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624eee32-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624eee32-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624eee32-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Welzijnszorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ef77e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ef77e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ef77e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f00b6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f00b6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f00b6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jongeren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f09ee-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f09ee-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f09ee-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kinderen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f12f4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f12f4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f12f4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personen met een beperking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f1c22-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f1c22-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f1c22-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale bescherming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f38ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f38ce-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f38ce-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Zorginfrastructuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f42d8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f42d8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f42d8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f4e18-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f4e18-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f4e18-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f5962-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f5962-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f5962-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugdbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f6484-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f6484-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f6484-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f717c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f717c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f717c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f7cda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f7cda-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f7cda-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f86d0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f86d0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f86d0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werkgelegenheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f90f8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f90f8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f90f8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele vorming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624f9bde-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624f9bde-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624f9bde-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624fa642-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624fa642-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624fa642-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624fb056-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624fb056-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624fb056-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624fbaa6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624fbaa6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624fbaa6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624fc4f6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624fc4f6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624fc4f6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Leefmilieu en natuur, hierin begrepen de uitvoering van de handhavingstaken met betrekking tot ruimtelijke ordening en onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624fcf00-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624fcf00-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624fcf00-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624fd8ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624fd8ce-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624fd8ce-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Dierenwelzijn"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624fe2ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624fe2ce-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624fe2ce-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624fecec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624fecec-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624fecec-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/624ff71e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/624ff71e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "624ff71e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62500128-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62500128-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62500128-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62500b78-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62500b78-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62500b78-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Verkeersbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625016fe-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625016fe-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625016fe-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ruimtelijke ordening, met uitzondering van de uitvoering van handhavingstaken, vermeld in artikel 13, § 1, 7°"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62502130-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62502130-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62502130-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Woonbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62502b58-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62502b58-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62502b58-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2017-03-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2016-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beheer en bescherming onroerend erfgoed, met uitzondering van de uitvoering van handhavingstaken, vermeld in artikel 13, § 1, 8°, tenzij uitdrukkelijk anders bepaald"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62503594-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62503594-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62503594-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62503fda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62503fda-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62503fda-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning organisatiegerichte en beleidsdomeinoverschrijdende thema's"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625049da-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625049da-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625049da-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gelijke kansen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625053e4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625053e4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625053e4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Brussel"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62505e16-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62505e16-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62505e16-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6250682a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6250682a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6250682a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Audit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62507234-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62507234-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62507234-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Rampenschade"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62507d4c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62507d4c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62507d4c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 8 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Informatiemanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625087b0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625087b0-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625087b0-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 9 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625091c4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625091c4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625091c4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 10 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "ICT"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62509c50-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62509c50-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62509c50-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 11 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1binnenland"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6250a740-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6250a740-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6250a740-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 12 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1stedenbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6250b29e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6250b29e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6250b29e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 13 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1integratie en inburgering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6250bca8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6250bca8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6250bca8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 14 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "1personeel en organisatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6250c6bc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6250c6bc-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6250c6bc-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6250d0f8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6250d0f8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6250d0f8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6250dbde-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6250dbde-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6250dbde-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgettair beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6250e624-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6250e624-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6250e624-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlandse en Europese aangelegenheden"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6250efde-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6250efde-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6250efde-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ontwikkelingssamenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6250fa24-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6250fa24-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6250fa24-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62510410-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62510410-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62510410-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62510dd4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62510dd4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62510dd4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62511806-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62511806-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62511806-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62512328-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62512328-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62512328-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62512e5e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62512e5e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62512e5e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschapscommunicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625138d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625138d6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625138d6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62514268-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62514268-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62514268-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62514c9a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62514c9a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62514c9a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625155d2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625155d2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625155d2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62515f14-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62515f14-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62515f14-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beleidsthema's onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62516874-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62516874-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62516874-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Welzijnszorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625172ba-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625172ba-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625172ba-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62517d1e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62517d1e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62517d1e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jongeren"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6251876e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6251876e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6251876e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kinderen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625191aa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625191aa-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625191aa-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personen met een beperking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62519c90-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62519c90-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62519c90-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale bescherming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6251a6b8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6251a6b8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6251a6b8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Zorginfrastructuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6251b0a4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6251b0a4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6251b0a4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6251bc2a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6251bc2a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6251bc2a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6251c710-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6251c710-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6251c710-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugdbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6251d0de-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6251d0de-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6251d0de-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6251dba6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6251dba6-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6251dba6-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6251e592-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6251e592-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6251e592-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6251efe2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6251efe2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6251efe2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werkgelegenheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6251f9ba-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6251f9ba-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6251f9ba-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Professionele vorming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625203ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625203ce-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625203ce-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62520dc4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62520dc4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62520dc4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62521940-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62521940-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62521940-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62522340-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62522340-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62522340-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62522c78-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62522c78-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62522c78-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252363c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252363c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252363c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62524032-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62524032-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62524032-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62524a6e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62524a6e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62524a6e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252554a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252554a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252554a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Verkeersbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62525fc2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62525fc2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62525fc2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ruimtelijke ordening"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625269f4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625269f4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625269f4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Woonbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625274f8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625274f8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625274f8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62527f66-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62527f66-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62527f66-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Milieu en natuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62528a24-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62528a24-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62528a24-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625293f2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625293f2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625293f2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
-    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2019-10-01T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2017-04-01T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Dierenwelzijn"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62529d02-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62529d02-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62529d02-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252a69e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252a69e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252a69e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gelijke kansen en integratie en inburgering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252b17a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252b17a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252b17a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Brussel"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252bc4c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252bc4c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252bc4c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Vlaamse rand"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252c64c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252c64c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252c64c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Binnenlands bestuur en stedenbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252d074-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252d074-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252d074-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Rampenschade"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252da9c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252da9c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252da9c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Digitalisering"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252e47e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252e47e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252e47e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 8 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Bestuursrechtspraak"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252ef0a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252ef0a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252ef0a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 9 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Interne dienstverlening Vlaamse overheid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6252f8ec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6252f8ec-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6252f8ec-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgettair beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62530382-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62530382-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62530382-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62530f58-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62530f58-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62530f58-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Financiële operaties"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62531a66-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62531a66-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62531a66-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Boekhouding"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253242a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253242a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253242a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Buitenlands beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62532e0c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62532e0c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62532e0c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ontwikkelingssamenwerking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62533834-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62533834-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62533834-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Toerisme"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62534266-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62534266-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62534266-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62534c70-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62534c70-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62534c70-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62535634-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62535634-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62535634-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62536070-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62536070-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62536070-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62536a84-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62536a84-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62536a84-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wetenschapscommunicatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62537466-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62537466-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62537466-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62537e66-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62537e66-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62537e66-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253888e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253888e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253888e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62539356-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62539356-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62539356-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62539e8c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62539e8c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62539e8c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Welzijn"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253a882-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253a882-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253a882-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheids- en woonzorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253b282-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253b282-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253b282-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Opgroeien"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253bd40-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253bd40-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253bd40-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personen met een beperking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253c75e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253c75e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253c75e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale bescherming"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253d14a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253d14a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253d14a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Zorginfrastructuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253dbc2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253dbc2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253dbc2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Cultuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253e5a4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253e5a4-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253e5a4-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Jeugd"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253efae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253efae-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253efae-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Media"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6253f9b8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6253f9b8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6253f9b8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sport"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62540412-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62540412-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62540412-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62540e12-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62540e12-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62540e12-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Competenties"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625417ae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625417ae-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625417ae-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Sociale economie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625421ae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625421ae-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625421ae-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62542c30-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62542c30-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62542c30-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw- en zeevisserijonderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6254377a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6254377a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6254377a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62544210-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62544210-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62544210-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62544be8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62544be8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62544be8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62545642-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62545642-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62545642-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Algemeen mobiliteitsbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62546042-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62546042-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62546042-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62546a2e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62546a2e-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62546a2e-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Waterinfrastructuur en beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/625473e8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/625473e8-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "625473e8-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62547e4c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62547e4c-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62547e4c-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Omgeving en natuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62548982-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62548982-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62548982-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Klimaat"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62549292-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62549292-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62549292-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/62549bf2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/62549bf2-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "62549bf2-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 5 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Dierenwelzijn"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/6254a57a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/6254a57a-3db6-11ed-ba35-88d7f641cbef> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "6254a57a-3db6-11ed-ba35-88d7f641cbef" ;
-    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
-    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    prov:invalidatedAtTime "2020-08-31T23:59:59"^^xsd:dateTime ;
+    prov:generatedAtTime "2019-10-02T00:00:00"^^xsd:dateTime ;
     schema:position 6 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Wonen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/64634310-4c8d-46a3-ac4a-e7777a434729> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/64634310-4c8d-46a3-ac4a-e7777a434729> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "64634310-4c8d-46a3-ac4a-e7777a434729" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 11 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Justitie en handhaving"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/72b6fc10-b729-40f3-9c03-9f7d55e076a7> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/72b6fc10-b729-40f3-9c03-9f7d55e076a7> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "72b6fc10-b729-40f3-9c03-9f7d55e076a7" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Personen met een beperking"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/80106fa7-3f9d-4313-b3e1-040bf0e07410> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/80106fa7-3f9d-4313-b3e1-040bf0e07410> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "80106fa7-3f9d-4313-b3e1-040bf0e07410" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Budgettair beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/82208ea2-8371-4ed1-906f-5ae4c101caee> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/82208ea2-8371-4ed1-906f-5ae4c101caee> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "82208ea2-8371-4ed1-906f-5ae4c101caee" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Welzijn"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/82883c33-57c8-4e67-9669-53ef7f960b51> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/82883c33-57c8-4e67-9669-53ef7f960b51> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "82883c33-57c8-4e67-9669-53ef7f960b51" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 7 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Binnenlands bestuur en stedenbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/890bcc01-a3f2-40de-954b-92ea3d958784> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/890bcc01-a3f2-40de-954b-92ea3d958784> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "890bcc01-a3f2-40de-954b-92ea3d958784" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Innovatie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/8f23ea03-637f-4d4b-8135-7281a6358ab1> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/8f23ea03-637f-4d4b-8135-7281a6358ab1> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "8f23ea03-637f-4d4b-8135-7281a6358ab1" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/998b165e-3c6d-4722-bd1f-af3de421628e> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/998b165e-3c6d-4722-bd1f-af3de421628e> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "998b165e-3c6d-4722-bd1f-af3de421628e" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Boekhouding"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/9bae7bf3-3851-4447-b457-5af1b0c82925> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/9bae7bf3-3851-4447-b457-5af1b0c82925> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "9bae7bf3-3851-4447-b457-5af1b0c82925" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Werk"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/a84f868d-de05-4a62-b7eb-fc676479a6d2> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/a84f868d-de05-4a62-b7eb-fc676479a6d2> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "a84f868d-de05-4a62-b7eb-fc676479a6d2" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Weginfrastructuur en beleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/b2cdd186-bced-41af-9533-7e234996f16e> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/b2cdd186-bced-41af-9533-7e234996f16e> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "b2cdd186-bced-41af-9533-7e234996f16e" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Hoger onderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/b5eb0138-b286-473e-8f06-5647db7ac120> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/b5eb0138-b286-473e-8f06-5647db7ac120> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "b5eb0138-b286-473e-8f06-5647db7ac120" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Algemeen mobiliteitsbeleid"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/bc15da36-a7a3-46eb-9af6-d6a8a12b0ad1> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/bc15da36-a7a3-46eb-9af6-d6a8a12b0ad1> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "bc15da36-a7a3-46eb-9af6-d6a8a12b0ad1" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw- en zeevisserijonderzoek"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/c08ccb06-460f-4bb7-87d5-714a94c5186b> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/c08ccb06-460f-4bb7-87d5-714a94c5186b> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "c08ccb06-460f-4bb7-87d5-714a94c5186b" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Competenties"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/c48135d7-f235-460a-af3b-deb3954e6a32> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/c48135d7-f235-460a-af3b-deb3954e6a32> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "c48135d7-f235-460a-af3b-deb3954e6a32" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Onroerend erfgoed"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/cd9b9d89-5757-448d-a887-10acfc67adfb> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/cd9b9d89-5757-448d-a887-10acfc67adfb> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "cd9b9d89-5757-448d-a887-10acfc67adfb" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/d185e71b-2a6f-49e5-b710-3d9f58ddf11b> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/d185e71b-2a6f-49e5-b710-3d9f58ddf11b> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "d185e71b-2a6f-49e5-b710-3d9f58ddf11b" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 3 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Klimaat"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/d1b93810-6066-4b0e-ad31-130c7ae838ac> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/d1b93810-6066-4b0e-ad31-130c7ae838ac> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "d1b93810-6066-4b0e-ad31-130c7ae838ac" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Omgeving en natuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/d5193292-bdc1-4c7d-ba0a-661219108801> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/d5193292-bdc1-4c7d-ba0a-661219108801> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "d5193292-bdc1-4c7d-ba0a-661219108801" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Regionale luchthavens"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/d83bfbfd-5821-4cf3-85cc-c7201f9343a6> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/d83bfbfd-5821-4cf3-85cc-c7201f9343a6> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "d83bfbfd-5821-4cf3-85cc-c7201f9343a6" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Gezondheids- en woonzorg"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/da9202a5-c504-4f2c-8865-055cf472b3e4> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/da9202a5-c504-4f2c-8865-055cf472b3e4> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "da9202a5-c504-4f2c-8865-055cf472b3e4" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 2 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Fiscaliteit"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/e4d93deb-7e21-4838-b83d-da6b8c562723> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/e4d93deb-7e21-4838-b83d-da6b8c562723> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "e4d93deb-7e21-4838-b83d-da6b8c562723" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 14 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Internationaal ondernemen"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/e4dab90c-bb3a-47c5-abfc-802ddb55480d> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/e4dab90c-bb3a-47c5-abfc-802ddb55480d> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "e4dab90c-bb3a-47c5-abfc-802ddb55480d" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Landbouw en zeevisserij"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/ea4c45da-a07d-49c9-92ab-16d0a0d4e37e> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/ea4c45da-a07d-49c9-92ab-16d0a0d4e37e> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "ea4c45da-a07d-49c9-92ab-16d0a0d4e37e" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Energie"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/eddfc369-3b67-45a1-b0a2-d527a03c1ce1> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/eddfc369-3b67-45a1-b0a2-d527a03c1ce1> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "eddfc369-3b67-45a1-b0a2-d527a03c1ce1" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/fc405ce9-5535-440d-a121-5deacab67d28> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/fc405ce9-5535-440d-a121-5deacab67d28> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "fc405ce9-5535-440d-a121-5deacab67d28" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 1 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
     skos:prefLabel "Cultuur"@nl ;
     skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
 
-<http://themis.vlaanderen.be/id/beleidsveld/ff815ebf-7a96-42be-90fc-88824854e6a6> a core:Beleidsveld,
+<http://themis.vlaanderen.be/id/beleidsveld/ff815ebf-7a96-42be-90fc-88824854e6a6> a ext:Beleidsveld,
         skos:Concept ;
     mu:uuid "ff815ebf-7a96-42be-90fc-88824854e6a6" ;
-    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    prov:generatedAtTime "2020-09-01T00:00:00"^^xsd:dateTime ;
     schema:position 4 ;
     skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
     skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;

--- a/config/migrations/20220926140002-beleidsvelden-themis-concepts.ttl
+++ b/config/migrations/20220926140002-beleidsvelden-themis-concepts.ttl
@@ -1,0 +1,7602 @@
+@prefix core: <http://kanselarij.vo.data.gift/core/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/01f64f4e-d435-4f98-8260-7e1843bf1555> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "01f64f4e-d435-4f98-8260-7e1843bf1555" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/08249005-75e6-4791-ac7f-dbbb3a4d79c4> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "08249005-75e6-4791-ac7f-dbbb3a4d79c4" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Opgroeien"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/0db685d1-811f-49f9-a6fe-348aab08bba4> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "0db685d1-811f-49f9-a6fe-348aab08bba4" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlands beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/0f693798-541d-49ee-b705-4643661402a2> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "0f693798-541d-49ee-b705-4643661402a2" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Vlaamse rand"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/106408c9-ec8e-42cf-9e8e-6a8e7ef537b1> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "106408c9-ec8e-42cf-9e8e-6a8e7ef537b1" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschapscommunicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/10d5f8a5-3dfe-4661-b6a2-c2ca98f819a3> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "10d5f8a5-3dfe-4661-b6a2-c2ca98f819a3" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financiële operaties"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/114e5c23-e495-41b7-995c-bc390b5234a0> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "114e5c23-e495-41b7-995c-bc390b5234a0" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/13842fbc-441c-46ca-a58d-f78a64eb8a93> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "13842fbc-441c-46ca-a58d-f78a64eb8a93" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/148a2622-b159-4bf7-b6f2-0ec8a5ce2194> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "148a2622-b159-4bf7-b6f2-0ec8a5ce2194" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/19c1626d-1172-48f9-81d7-368015eb3489> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "19c1626d-1172-48f9-81d7-368015eb3489" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugd"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 9 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Digitalisering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/2731fdbe-592b-414c-8675-22a7b9d7b3bc> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "2731fdbe-592b-414c-8675-22a7b9d7b3bc" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Zorginfrastructuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/2b0103aa-a3e8-4718-80f8-8de405966c57> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "2b0103aa-a3e8-4718-80f8-8de405966c57" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wonen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/32c9b7d9-6fe5-4e68-bd4f-0f895fadeb4c> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "32c9b7d9-6fe5-4e68-bd4f-0f895fadeb4c" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 8 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Rampenschade"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/35d0740c-2754-4ca3-a334-936401383bcf> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "35d0740c-2754-4ca3-a334-936401383bcf" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 13 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/3ada201d-68dd-41a3-b0da-5a8ef27de879> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "3ada201d-68dd-41a3-b0da-5a8ef27de879" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/43b8de2e-61f9-4cf8-a018-9f3cc27f4103> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "43b8de2e-61f9-4cf8-a018-9f3cc27f4103" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Dierenwelzijn"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/4cd5d9d1-099b-437e-be1a-99c069469fcb> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "4cd5d9d1-099b-437e-be1a-99c069469fcb" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale bescherming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/4d73b772-ccfa-4bd8-bd45-6722b1972a1a> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "4d73b772-ccfa-4bd8-bd45-6722b1972a1a" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 10 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Bestuursrechtspraak"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/4fbef468-55dd-4191-96bd-e0ac9e28aa91> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "4fbef468-55dd-4191-96bd-e0ac9e28aa91" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/52e877e2-d342-4b0c-9835-74368a296d6c> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "52e877e2-d342-4b0c-9835-74368a296d6c" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ontwikkelingssamenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/581845a0-0a25-4e43-89d6-7863572aeb6c> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "581845a0-0a25-4e43-89d6-7863572aeb6c" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/59e231ce-97d2-4576-a152-c2807eefa5b6> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "59e231ce-97d2-4576-a152-c2807eefa5b6" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 12 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Interne dienstverlening Vlaamse overheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/5a9c8b50-1d07-4bcb-9dd8-f1d041437a46> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "5a9c8b50-1d07-4bcb-9dd8-f1d041437a46" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/5de93340-ce1a-4886-8425-6c80bbe0351b> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "5de93340-ce1a-4886-8425-6c80bbe0351b" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623cc5cc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623cc5cc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d0fe6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d0fe6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Communicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d1a7c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d1a7c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Interne audit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d26c0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d26c0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Geografische informatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d31c4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d31c4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personeels- en organisatieontwikkeling"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d3c82-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d3c82-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "ICT"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d484e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d484e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Facilitaire dienstverlening en vastgoedbeheer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d537a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d537a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Binnenlandse aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d5e4c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d5e4c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Inburgeringsbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d693c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d693c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d7576-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d7576-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financieel en waarborgbeheer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d803e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d803e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgetcontrolling"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d8c64-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d8c64-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Algemene boekhouding"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623d984e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623d984e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623da32a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623da32a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623dadac-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623dadac-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationale samenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623db82e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623db82e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623dc36e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623dc36e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623dce0e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623dce0e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fundamenteel onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623dd8cc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623dd8cc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Strategisch en beleidsgericht onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623de4a2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623de4a2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Technologische innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623def92-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623def92-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Popularisering van de wetenschap"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623dfaaa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623dfaaa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e0554-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e0554-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e10a8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e10a8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Levenslang leren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e1b34-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e1b34-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning scholen, leerlingen en studenten"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e2746-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e2746-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheidszorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e329a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e329a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Algemeen welzijnswerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e3eb6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e3eb6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jongeren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e491a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e491a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ouderen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e5392-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e5392-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kinderen en gezinnen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e5e64-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e5e64-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale en maatschappelijke integratie voor bijzondere doelgroepen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e68fa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e68fa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Cultureel erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e73ae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e73ae-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele kunsten"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e7e3a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e7e3a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugdwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e8894-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e8894-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociaal-cultureel volwassenenwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e92ee-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e92ee-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623e9d5c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623e9d5c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623ea950-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623ea950-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werkgelegenheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623eb40e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623eb40e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele vorming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623ebee0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623ebee0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623ec836-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623ec836-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623ed222-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623ed222-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623edc68-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623edc68-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Leefmilieu"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623ee6f4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623ee6f4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterbeheer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623ef1b2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623ef1b2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landinrichting en nutriëntenbeheer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623efc20-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623efc20-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Natuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f0648-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f0648-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Plattelandsbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f1066-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f1066-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f1b7e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f1b7e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Natuurlijke rijkdommen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f2844-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f2844-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f3320-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f3320-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f3d7a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f3d7a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f491e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f491e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f6d90-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f6d90-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Verkeersveiligheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f7812-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f7812-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ruimtelijke ordening"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f8258-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f8258-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Woonbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f8cd0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f8cd0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623f984c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623f984c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623fa2a6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623fa2a6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Communicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623facec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623facec-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Interne audit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623fb7e6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623fb7e6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Geografische informatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623fc222-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623fc222-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personeels- en organisatieontwikkeling"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623fccf4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623fccf4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "ICT"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623fd712-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623fd712-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Facilitaire dienstverlening en vastgoedbeheer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623fe338-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623fe338-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Binnenlandse aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623fed7e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623fed7e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Inburgeringsbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/623ff7e2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "623ff7e2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240026e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240026e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financieel en waarborgbeheer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62400eda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62400eda-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgetcontrolling"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62401952-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62401952-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Algemene boekhouding"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624023ac-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624023ac-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240302c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240302c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62403aa4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62403aa4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationale samenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624044e0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624044e0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62404f44-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62404f44-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624059e4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624059e4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fundamenteel onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62406470-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62406470-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Strategisch en beleidsgericht onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62406ec0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62406ec0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Technologische innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624079c4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624079c4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Popularisering van de wetenschap"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240850e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240850e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62408fcc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62408fcc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62409a44-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62409a44-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Levenslang leren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240a520-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240a520-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning scholen, leerlingen en studenten"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240b0c4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240b0c4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheidszorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240baf6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240baf6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Algemeen welzijnswerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240c708-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240c708-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jongeren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240d31a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240d31a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ouderen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240dc8e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240dc8e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kinderen en gezinnen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240e684-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240e684-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale en maatschappelijke integratie voor bijzondere doelgroepen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240f106-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240f106-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Cultureel erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6240fb60-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6240fb60-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele kunsten"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62410588-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62410588-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugdwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62410fce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62410fce-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociaal-cultureel volwassenenwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62411bae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62411bae-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624125e0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624125e0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62412fea-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62412fea-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werkgelegenheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62413a9e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62413a9e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele vorming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62414656-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62414656-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6241518c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6241518c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62415aec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62415aec-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62416500-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62416500-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Leefmilieu"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62416e42-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62416e42-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterbeheer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62417798-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62417798-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landinrichting en nutriëntenbeheer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62418116-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62418116-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Natuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62418abc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62418abc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Plattelandsbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624194bc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624194bc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62419ef8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62419ef8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Natuurlijke rijkdommen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6241a97a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6241a97a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6241b438-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6241b438-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6241be92-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6241be92-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6241c86a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6241c86a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6241d7b0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6241d7b0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Verkeersveiligheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6241e458-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6241e458-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ruimtelijke ordening"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6241ef16-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6241ef16-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Woonbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6241f95c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6241f95c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2006-08-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624203fc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624203fc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62420e06-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62420e06-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning beleidsdomeinoverschrijdende thema's"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624217f2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624217f2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gelijke kansen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242222e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242222e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Brussel"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62422da0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62422da0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624237aa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624237aa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Interne audit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62424204-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62424204-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Geografische informatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62424bf0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62424bf0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624256d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624256d6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "ICT"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242611c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242611c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Binnenland"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624264fe-0e06-48c1-9e97-eeb4089f5971> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624264fe-0e06-48c1-9e97-eeb4089f5971" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Brussel"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62426dba-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62426dba-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Stedenbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624278be-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624278be-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Inburgering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62428444-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62428444-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personeel en organisatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62428e8a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62428e8a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62429880-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62429880-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242a384-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242a384-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgettair beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242adb6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242adb6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242b7e8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242b7e8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242c29c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242c29c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationale samenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242cd5a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242cd5a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242d75a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242d75a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242e1be-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242e1be-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242ed30-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242ed30-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6242f7f8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6242f7f8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschapscommunicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624301ee-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624301ee-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62430c20-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62430c20-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624316fc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624316fc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243225a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243225a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62432c5a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62432c5a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beleidsthema's onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62433650-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62433650-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Welzijnszorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243414a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243414a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62434bd6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62434bd6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jongeren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624355d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624355d6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kinderen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243603a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243603a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personen met een beperking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62436a76-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62436a76-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale bescherming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62437566-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62437566-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Zorginfrastructuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62437f84-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62437f84-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62438a56-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62438a56-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624394f6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624394f6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugdbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62439eec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62439eec-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243a914-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243a914-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243b5c6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243b5c6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243c016-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243c016-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werkgelegenheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243ca3e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243ca3e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele vorming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243d47a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243d47a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243dff6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243dff6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243ea28-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243ea28-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243f342-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243f342-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6243fd6a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6243fd6a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Leefmilieu en natuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624406de-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624406de-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244103e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244103e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624419bc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624419bc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244234e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244234e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62442cc2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62442cc2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624436d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624436d6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Verkeersbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62444266-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62444266-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ruimtelijke ordening"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62444edc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62444edc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Woonbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62445a4e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62445a4e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2013-12-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2006-08-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244639a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244639a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62446d04-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62446d04-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning beleidsdomeinoverschrijdende thema's"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244768c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244768c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gelijke kansen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62447fec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62447fec-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Brussel"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624488fc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624488fc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62449216-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62449216-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Audit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62449bd0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62449bd0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Geografische informatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244a4d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244a4d6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244ae2c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244ae2c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "ICT"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244b82c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244b82c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Binnenland"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244c1be-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244c1be-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Stedenbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244caf6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244caf6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Inburgering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244d53c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244d53c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personeel en organisatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244de7e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244de7e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244e8a6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244e8a6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244f24c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244f24c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgettair beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6244fb8e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6244fb8e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62450494-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62450494-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62450e1c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62450e1c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationale samenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624517fe-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624517fe-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624521f4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624521f4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62452c3a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62452c3a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245370c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245370c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62454260-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62454260-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschapscommunicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62454cba-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62454cba-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624555e8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624555e8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62455f2a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62455f2a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62456984-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62456984-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624572a8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624572a8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beleidsthema's onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62457be0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62457be0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Welzijnszorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624585cc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624585cc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62458f0e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62458f0e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jongeren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62459850-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62459850-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kinderen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245a174-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245a174-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personen met een beperking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245ad72-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245ad72-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale bescherming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245b6a0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245b6a0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Zorginfrastructuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245c000-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245c000-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245c938-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245c938-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245d284-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245d284-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugdbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245dbbc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245dbbc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245e4b8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245e4b8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245edd2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245edd2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6245f89a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6245f89a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werkgelegenheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624601e6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624601e6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele vorming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62460b0a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62460b0a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246147e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246147e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62461e38-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62461e38-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246275c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246275c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624630bc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624630bc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Leefmilieu en natuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624639a4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624639a4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624642be-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624642be-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62464c64-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62464c64-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62465588-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62465588-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62465ec0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62465ec0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624667d0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624667d0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Verkeersbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246711c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246711c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ruimtelijke ordening"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62467a4a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62467a4a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Woonbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624692b4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624692b4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2014-07-24T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-01-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62469c5a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62469c5a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246a628-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246a628-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning beleidsdomeinoverschrijdende thema's"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246b05a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246b05a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gelijke kansen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246baa0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246baa0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Brussel"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246c554-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246c554-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246cf68-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246cf68-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Audit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246d936-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246d936-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Geografische informatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246e386-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246e386-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246ee9e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246ee9e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "ICT"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6246f808-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6246f808-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Binnenland"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62470136-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62470136-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Stedenbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62470ac8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62470ac8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Inburgering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624713ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624713ce-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personeel en organisatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62471cca-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62471cca-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247274c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247274c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62473232-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62473232-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgettair beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62473c6e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62473c6e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247465a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247465a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247503c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247503c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationale samenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62475b04-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62475b04-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624765c2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624765c2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62476fc2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62476fc2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247799a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247799a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247850c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247850c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschapscommunicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624791aa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624791aa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62479cae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62479cae-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247a6fe-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247a6fe-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247b14e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247b14e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247bb58-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247bb58-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beleidsthema's onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247c6de-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247c6de-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Welzijnszorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247d138-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247d138-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247dafc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247dafc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jongeren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247e4fc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247e4fc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kinderen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247ef10-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247ef10-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personen met een beperking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6247f9ec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6247f9ec-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale bescherming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248040a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248040a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Zorginfrastructuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62480e46-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62480e46-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62481846-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62481846-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62482318-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62482318-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugdbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62482d4a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62482d4a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62483790-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62483790-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248421c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248421c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62484c30-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62484c30-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werkgelegenheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248564e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248564e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele vorming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624861e8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624861e8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62486c4c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62486c4c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62487728-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62487728-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62488132-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62488132-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62488c18-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62488c18-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Leefmilieu en natuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624896ea-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624896ea-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248a180-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248a180-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Dierenwelzijn"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248aa9a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248aa9a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248b3fa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248b3fa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248bdc8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248bdc8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248c6ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248c6ce-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248cfe8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248cfe8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Verkeersbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248d8f8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248d8f8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ruimtelijke ordening"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248e258-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248e258-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Woonbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248eec4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248eec4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2015-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2014-07-25T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6248f9e6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6248f9e6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249042c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249042c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning organisatiegerichte en beleidsdomeinoverschrijdende thema's"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62490ecc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62490ecc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gelijke kansen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624918cc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624918cc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Brussel"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624922d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624922d6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62492e8e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62492e8e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Audit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249397e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249397e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Rampenschade"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249434c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249434c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 8 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Informatiemanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62494ce8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62494ce8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 9 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249576a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249576a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 10 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "ICT"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624962c8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624962c8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 11 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1binnenland"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62496c0a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62496c0a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 12 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1stedenbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249756a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249756a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 13 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1integratie en inburgering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62497eac-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62497eac-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 14 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1personeel en organisatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62498906-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62498906-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249923e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249923e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62499b3a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62499b3a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgettair beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249a4a4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249a4a4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlandse aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249ae04-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249ae04-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249b78c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249b78c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationale samenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249c1aa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249c1aa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme, met inbegrip van vrijetijdsbesteding in het kader van toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249cc54-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249cc54-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249d636-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249d636-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249e04a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249e04a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249ea54-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249ea54-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschapscommunicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249f4b8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249f4b8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6249ffda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6249ffda-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a09a8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a09a8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a17fe-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a17fe-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a2208-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a2208-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beleidsthema's onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a2c30-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a2c30-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Welzijnszorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a3644-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a3644-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a408a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a408a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jongeren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a4a8a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a4a8a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kinderen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a5430-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a5430-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personen met een beperking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a5e58-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a5e58-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale bescherming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a6902-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a6902-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Zorginfrastructuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a7348-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a7348-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a7d66-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a7d66-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a87de-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a87de-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugdbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a9378-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a9378-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624a9db4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624a9db4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624aa70a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624aa70a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ab1aa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ab1aa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werkgelegenheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624abae2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624abae2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele vorming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ac41a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ac41a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624acd20-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624acd20-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ad630-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ad630-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624adf68-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624adf68-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ae88c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ae88c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Leefmilieu en natuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624af19c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624af19c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624afda4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624afda4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Dierenwelzijn"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b0844-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b0844-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b115e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b115e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b1ad2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b1ad2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b23ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b23ce-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b2e1e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b2e1e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Verkeersbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b37ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b37ce-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ruimtelijke ordening"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b42fa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b42fa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Woonbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b4d22-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b4d22-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-01-29T23:59:59"^^xsd:dateTime ;
+    ext:start "2015-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b57d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b57d6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b61b8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b61b8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning organisatiegerichte en beleidsdomeinoverschrijdende thema's"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b6bcc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b6bcc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gelijke kansen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b7612-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b7612-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Brussel"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b8008-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b8008-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b8a44-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b8a44-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Audit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b9462-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b9462-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Rampenschade"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624b9f20-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624b9f20-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 8 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Informatiemanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ba902-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ba902-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 9 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624bb30c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624bb30c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 10 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "ICT"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624bbcda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624bbcda-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 11 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1binnenland"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624bc720-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624bc720-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 12 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1stedenbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624bd22e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624bd22e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 13 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1integratie en inburgering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624bdcc4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624bdcc4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 14 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1personeel en organisatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624be5ac-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624be5ac-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624bef34-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624bef34-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624bf858-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624bf858-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgettair beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c0186-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c0186-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlandse en Europese aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c0ab4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c0ab4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ontwikkelingssamenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c1414-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c1414-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c1d2e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c1d2e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c2634-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c2634-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c3246-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c3246-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c3da4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c3da4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c4916-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c4916-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschapscommunicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c5384-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c5384-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c5c76-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c5c76-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c65f4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c65f4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c7148-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c7148-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c7b20-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c7b20-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beleidsthema's onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c85b6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c85b6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Welzijnszorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c9088-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c9088-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624c9aba-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624c9aba-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jongeren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ca4d8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ca4d8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kinderen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624caf3c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624caf3c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personen met een beperking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624cb914-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624cb914-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale bescherming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624cc364-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624cc364-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Zorginfrastructuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ccd5a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ccd5a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624cd840-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624cd840-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ce376-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ce376-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugdbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ceccc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ceccc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624cf622-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624cf622-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624cffaa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624cffaa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d0bda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d0bda-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werkgelegenheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d1616-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d1616-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele vorming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d1fee-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d1fee-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d2ab6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d2ab6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d36be-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d36be-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d40dc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d40dc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d4a46-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d4a46-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Leefmilieu en natuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d543c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d543c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d5e3c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d5e3c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Dierenwelzijn"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d6864-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d6864-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d732c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d732c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d7e1c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d7e1c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d88d0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d88d0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d91c2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d91c2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Verkeersbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624d9b72-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624d9b72-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ruimtelijke ordening"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624db382-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624db382-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Woonbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624dbd96-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624dbd96-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2016-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-01-30T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624dc836-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624dc836-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624dd236-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624dd236-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning organisatiegerichte en beleidsdomeinoverschrijdende thema's"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ddc2c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ddc2c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gelijke kansen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624de794-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624de794-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Brussel"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624df27a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624df27a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624dfd88-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624dfd88-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Audit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e06ca-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e06ca-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Rampenschade"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e10fc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e10fc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 8 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Informatiemanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e1a02-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e1a02-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 9 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e231c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e231c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 10 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "ICT"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e2c22-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e2c22-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 11 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1binnenland"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e35c8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e35c8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 12 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1stedenbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e405e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e405e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 13 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1integratie en inburgering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e4964-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e4964-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 14 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1personeel en organisatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e52b0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e52b0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e5c10-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e5c10-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e6552-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e6552-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgettair beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e6e8a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e6e8a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlandse en Europese aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e77ae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e77ae-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ontwikkelingssamenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e8104-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e8104-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e8afa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e8afa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e940a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e940a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624e9d2e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624e9d2e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ea666-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ea666-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624eb034-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624eb034-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschapscommunicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624eb980-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624eb980-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ec2ae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ec2ae-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ecde4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ecde4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ed8ca-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ed8ca-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ee482-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ee482-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beleidsthema's onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624eee32-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624eee32-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Welzijnszorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ef77e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ef77e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f00b6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f00b6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jongeren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f09ee-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f09ee-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kinderen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f12f4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f12f4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personen met een beperking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f1c22-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f1c22-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale bescherming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f38ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f38ce-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Zorginfrastructuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f42d8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f42d8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f4e18-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f4e18-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f5962-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f5962-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugdbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f6484-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f6484-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f717c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f717c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f7cda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f7cda-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f86d0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f86d0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werkgelegenheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f90f8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f90f8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele vorming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624f9bde-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624f9bde-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624fa642-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624fa642-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624fb056-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624fb056-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624fbaa6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624fbaa6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624fc4f6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624fc4f6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Leefmilieu en natuur, hierin begrepen de uitvoering van de handhavingstaken met betrekking tot ruimtelijke ordening en onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624fcf00-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624fcf00-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624fd8ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624fd8ce-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Dierenwelzijn"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624fe2ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624fe2ce-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624fecec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624fecec-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/624ff71e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "624ff71e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62500128-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62500128-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62500b78-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62500b78-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Verkeersbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625016fe-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625016fe-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ruimtelijke ordening, met uitzondering van de uitvoering van handhavingstaken, vermeld in artikel 13, § 1, 7°"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62502130-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62502130-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Woonbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62502b58-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62502b58-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2017-03-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2016-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beheer en bescherming onroerend erfgoed, met uitzondering van de uitvoering van handhavingstaken, vermeld in artikel 13, § 1, 8°, tenzij uitdrukkelijk anders bepaald"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62503594-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62503594-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62503fda-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62503fda-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning organisatiegerichte en beleidsdomeinoverschrijdende thema's"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625049da-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625049da-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gelijke kansen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625053e4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625053e4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Brussel"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62505e16-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62505e16-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Coördinatie Vlaamse Rand"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6250682a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6250682a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Audit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62507234-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62507234-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Rampenschade"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62507d4c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62507d4c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 8 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Informatiemanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625087b0-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625087b0-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 9 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Facilitaire dienstverlening en vastgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625091c4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625091c4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 10 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "ICT"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62509c50-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62509c50-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 11 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1binnenland"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6250a740-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6250a740-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 12 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1stedenbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6250b29e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6250b29e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 13 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1integratie en inburgering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6250bca8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6250bca8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 14 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "1personeel en organisatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6250c6bc-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6250c6bc-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6250d0f8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6250d0f8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financieel beheer, controle en risicomanagement"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6250dbde-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6250dbde-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgettair beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6250e624-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6250e624-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlandse en Europese aangelegenheden"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6250efde-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6250efde-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ontwikkelingssamenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6250fa24-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6250fa24-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62510410-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62510410-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62510dd4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62510dd4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62511806-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62511806-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62512328-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62512328-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62512e5e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62512e5e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschapscommunicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625138d6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625138d6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62514268-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62514268-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62514c9a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62514c9a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625155d2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625155d2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62515f14-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62515f14-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beleidsthema's onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62516874-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62516874-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Welzijnszorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625172ba-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625172ba-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheids- en ouderenzorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62517d1e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62517d1e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jongeren"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6251876e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6251876e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kinderen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625191aa-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625191aa-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personen met een beperking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62519c90-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62519c90-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale bescherming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6251a6b8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6251a6b8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Zorginfrastructuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6251b0a4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6251b0a4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele kunsten en cultureel erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6251bc2a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6251bc2a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Transversaal beleid cultuur, jeugd, sport en media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6251c710-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6251c710-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugdbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6251d0de-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6251d0de-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociaal cultureel volwassenenwerk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6251dba6-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6251dba6-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6251e592-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6251e592-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6251efe2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6251efe2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werkgelegenheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6251f9ba-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6251f9ba-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Professionele vorming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625203ce-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625203ce-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62520dc4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62520dc4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62521940-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62521940-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62522340-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62522340-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw- en visserijonderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62522c78-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62522c78-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252363c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252363c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en zeewezen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62524032-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62524032-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en wegverkeer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62524a6e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62524a6e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252554a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252554a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Verkeersbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62525fc2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62525fc2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ruimtelijke ordening"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625269f4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625269f4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Woonbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625274f8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625274f8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Beheer en bescherming onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62527f66-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62527f66-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Milieu en natuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62528a24-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62528a24-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625293f2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625293f2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2019-10-01T23:59:59"^^xsd:dateTime ;
+    ext:start "2017-04-01T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Dierenwelzijn"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62529d02-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62529d02-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning Vlaamse Regering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252a69e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252a69e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gelijke kansen en integratie en inburgering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252b17a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252b17a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Brussel"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252bc4c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252bc4c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Vlaamse rand"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252c64c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252c64c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Binnenlands bestuur en stedenbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252d074-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252d074-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Rampenschade"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252da9c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252da9c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Digitalisering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252e47e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252e47e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 8 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Bestuursrechtspraak"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252ef0a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252ef0a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 9 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Interne dienstverlening Vlaamse overheid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6252f8ec-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6252f8ec-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgettair beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62530382-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62530382-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62530f58-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62530f58-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Financiële operaties"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62531a66-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62531a66-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Boekhouding"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253242a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253242a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Buitenlands beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62532e0c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62532e0c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ontwikkelingssamenwerking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62533834-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62533834-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Toerisme"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62534266-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62534266-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62534c70-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62534c70-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62535634-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62535634-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschappelijk onderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62536070-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62536070-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62536a84-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62536a84-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wetenschapscommunicatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62537466-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62537466-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62537e66-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62537e66-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253888e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253888e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62539356-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62539356-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Ondersteuning van het onderwijsveld"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62539e8c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62539e8c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Welzijn"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253a882-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253a882-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheids- en woonzorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253b282-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253b282-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Opgroeien"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253bd40-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253bd40-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personen met een beperking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253c75e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253c75e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale bescherming"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253d14a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253d14a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Zorginfrastructuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253dbc2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253dbc2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Cultuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253e5a4-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253e5a4-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Jeugd"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253efae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253efae-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Media"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6253f9b8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6253f9b8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sport"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62540412-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62540412-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62540e12-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62540e12-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Competenties"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625417ae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625417ae-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Sociale economie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625421ae-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625421ae-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62542c30-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62542c30-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw- en zeevisserijonderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6254377a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6254377a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Promotie landbouw, tuinbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62544210-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62544210-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62544be8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62544be8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62545642-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62545642-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Algemeen mobiliteitsbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62546042-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62546042-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62546a2e-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62546a2e-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Waterinfrastructuur en beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/625473e8-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "625473e8-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62547e4c-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62547e4c-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Omgeving en natuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62548982-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62548982-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Klimaat"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62549292-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62549292-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/62549bf2-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "62549bf2-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 5 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Dierenwelzijn"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/6254a57a-3db6-11ed-ba35-88d7f641cbef> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "6254a57a-3db6-11ed-ba35-88d7f641cbef" ;
+    ext:einde "2020-08-31T23:59:59"^^xsd:dateTime ;
+    ext:start "2019-10-02T00:00:00"^^xsd:dateTime ;
+    schema:position 6 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Wonen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/64634310-4c8d-46a3-ac4a-e7777a434729> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "64634310-4c8d-46a3-ac4a-e7777a434729" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 11 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Justitie en handhaving"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/72b6fc10-b729-40f3-9c03-9f7d55e076a7> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "72b6fc10-b729-40f3-9c03-9f7d55e076a7" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Personen met een beperking"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/80106fa7-3f9d-4313-b3e1-040bf0e07410> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "80106fa7-3f9d-4313-b3e1-040bf0e07410" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Budgettair beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/82208ea2-8371-4ed1-906f-5ae4c101caee> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "82208ea2-8371-4ed1-906f-5ae4c101caee" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Welzijn"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/82883c33-57c8-4e67-9669-53ef7f960b51> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "82883c33-57c8-4e67-9669-53ef7f960b51" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 7 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Binnenlands bestuur en stedenbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/890bcc01-a3f2-40de-954b-92ea3d958784> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "890bcc01-a3f2-40de-954b-92ea3d958784" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Innovatie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/8f23ea03-637f-4d4b-8135-7281a6358ab1> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "8f23ea03-637f-4d4b-8135-7281a6358ab1" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gemeenschappelijk vervoer"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/998b165e-3c6d-4722-bd1f-af3de421628e> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "998b165e-3c6d-4722-bd1f-af3de421628e" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Boekhouding"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/9bae7bf3-3851-4447-b457-5af1b0c82925> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "9bae7bf3-3851-4447-b457-5af1b0c82925" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Werk"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/a84f868d-de05-4a62-b7eb-fc676479a6d2> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "a84f868d-de05-4a62-b7eb-fc676479a6d2" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Weginfrastructuur en beleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/b2cdd186-bced-41af-9533-7e234996f16e> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "b2cdd186-bced-41af-9533-7e234996f16e" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Hoger onderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/b5eb0138-b286-473e-8f06-5647db7ac120> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "b5eb0138-b286-473e-8f06-5647db7ac120" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Algemeen mobiliteitsbeleid"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/bc15da36-a7a3-46eb-9af6-d6a8a12b0ad1> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "bc15da36-a7a3-46eb-9af6-d6a8a12b0ad1" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw- en zeevisserijonderzoek"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/c08ccb06-460f-4bb7-87d5-714a94c5186b> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "c08ccb06-460f-4bb7-87d5-714a94c5186b" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Competenties"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/c48135d7-f235-460a-af3b-deb3954e6a32> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "c48135d7-f235-460a-af3b-deb3954e6a32" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Onroerend erfgoed"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/cd9b9d89-5757-448d-a887-10acfc67adfb> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "cd9b9d89-5757-448d-a887-10acfc67adfb" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Deeltijds kunstonderwijs en volwassenenonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/d185e71b-2a6f-49e5-b710-3d9f58ddf11b> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "d185e71b-2a6f-49e5-b710-3d9f58ddf11b" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 3 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Klimaat"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/d1b93810-6066-4b0e-ad31-130c7ae838ac> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "d1b93810-6066-4b0e-ad31-130c7ae838ac" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Omgeving en natuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/d5193292-bdc1-4c7d-ba0a-661219108801> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "d5193292-bdc1-4c7d-ba0a-661219108801" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Regionale luchthavens"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/d83bfbfd-5821-4cf3-85cc-c7201f9343a6> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "d83bfbfd-5821-4cf3-85cc-c7201f9343a6" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gezondheids- en woonzorg"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/da9202a5-c504-4f2c-8865-055cf472b3e4> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "da9202a5-c504-4f2c-8865-055cf472b3e4" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 2 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Fiscaliteit"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/e4d93deb-7e21-4838-b83d-da6b8c562723> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "e4d93deb-7e21-4838-b83d-da6b8c562723" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 14 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Internationaal ondernemen"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/e4dab90c-bb3a-47c5-abfc-802ddb55480d> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "e4dab90c-bb3a-47c5-abfc-802ddb55480d" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Landbouw en zeevisserij"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/ea4c45da-a07d-49c9-92ab-16d0a0d4e37e> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "ea4c45da-a07d-49c9-92ab-16d0a0d4e37e" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Energie"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/eddfc369-3b67-45a1-b0a2-d527a03c1ce1> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "eddfc369-3b67-45a1-b0a2-d527a03c1ce1" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Kleuter- en leerplichtonderwijs"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/fc405ce9-5535-440d-a121-5deacab67d28> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "fc405ce9-5535-440d-a121-5deacab67d28" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 1 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Cultuur"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsveld/ff815ebf-7a96-42be-90fc-88824854e6a6> a core:Beleidsveld,
+        skos:Concept ;
+    mu:uuid "ff815ebf-7a96-42be-90fc-88824854e6a6" ;
+    ext:start "2020-09-01T00:00:00"^^xsd:dateTime ;
+    schema:position 4 ;
+    skos:broader <http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> ;
+    skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> ;
+    skos:prefLabel "Gelijke kansen en integratie en inburgering"@nl ;
+    skos:topConceptOf <http://themis.vlaanderen.be/id/concept-scheme/0012aad8-d6e5-49e2-af94-b1bebd484d5b> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/66d2ca3e-5bcf-405c-b704-4621004d051b> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/623d984e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623da32a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623dadac-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623db82e-3db6-11ed-ba35-88d7f641cbef> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/22a39165-e17c-4a52-963a-9fa3d097907c> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/01f64f4e-d435-4f98-8260-7e1843bf1555>,
+        <http://themis.vlaanderen.be/id/beleidsveld/0db685d1-811f-49f9-a6fe-348aab08bba4>,
+        <http://themis.vlaanderen.be/id/beleidsveld/0f693798-541d-49ee-b705-4643661402a2>,
+        <http://themis.vlaanderen.be/id/beleidsveld/1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2>,
+        <http://themis.vlaanderen.be/id/beleidsveld/32c9b7d9-6fe5-4e68-bd4f-0f895fadeb4c>,
+        <http://themis.vlaanderen.be/id/beleidsveld/35d0740c-2754-4ca3-a334-936401383bcf>,
+        <http://themis.vlaanderen.be/id/beleidsveld/4d73b772-ccfa-4bd8-bd45-6722b1972a1a>,
+        <http://themis.vlaanderen.be/id/beleidsveld/52e877e2-d342-4b0c-9835-74368a296d6c>,
+        <http://themis.vlaanderen.be/id/beleidsveld/59e231ce-97d2-4576-a152-c2807eefa5b6>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624264fe-0e06-48c1-9e97-eeb4089f5971>,
+        <http://themis.vlaanderen.be/id/beleidsveld/64634310-4c8d-46a3-ac4a-e7777a434729>,
+        <http://themis.vlaanderen.be/id/beleidsveld/82883c33-57c8-4e67-9669-53ef7f960b51>,
+        <http://themis.vlaanderen.be/id/beleidsveld/e4d93deb-7e21-4838-b83d-da6b8c562723>,
+        <http://themis.vlaanderen.be/id/beleidsveld/ff815ebf-7a96-42be-90fc-88824854e6a6> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/5a0d6e96-061d-4d91-900d-173d138f79a4> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/2b0103aa-a3e8-4718-80f8-8de405966c57>,
+        <http://themis.vlaanderen.be/id/beleidsveld/43b8de2e-61f9-4cf8-a018-9f3cc27f4103>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62525fc2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625269f4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625274f8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62527f66-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62528a24-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625293f2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625473e8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62547e4c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62548982-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62549292-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62549bf2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6254a57a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/c48135d7-f235-460a-af3b-deb3954e6a32>,
+        <http://themis.vlaanderen.be/id/beleidsveld/d185e71b-2a6f-49e5-b710-3d9f58ddf11b>,
+        <http://themis.vlaanderen.be/id/beleidsveld/d1b93810-6066-4b0e-ad31-130c7ae838ac>,
+        <http://themis.vlaanderen.be/id/beleidsveld/ea4c45da-a07d-49c9-92ab-16d0a0d4e37e> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/90ca98c8-efc4-4fa6-8124-51208cc353ee> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/623f7812-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f8258-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f8cd0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6241e458-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6241ef16-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6241f95c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62444266-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62444edc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62445a4e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246711c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62467a4a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624692b4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248d8f8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248e258-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248eec4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b37ce-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b42fa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b4d22-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d9b72-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624db382-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624dbd96-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625016fe-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62502130-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62502b58-3db6-11ed-ba35-88d7f641cbef> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/d371aadd-73c5-420d-bc4e-f1eacbfaf023> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/623d31c4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d3c82-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d484e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d537a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d5e4c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623fc222-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623fccf4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623fd712-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623fe338-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623fed7e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62424bf0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624256d6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242611c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62426dba-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624278be-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62428444-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244a4d6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244ae2c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244b82c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244c1be-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244caf6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244d53c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246e386-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246ee9e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246f808-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62470136-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62470ac8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624713ce-3db6-11ed-ba35-88d7f641cbef> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/c23a60f3-ffaf-44ef-be18-ff1792117caa> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/623cc5cc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d0fe6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d1a7c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d26c0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f984c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623fa2a6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623facec-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623fb7e6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624203fc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62420e06-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624217f2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242222e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62422da0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624237aa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62424204-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244639a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62446d04-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244768c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62447fec-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624488fc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62449216-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62449bd0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62469c5a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246a628-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246b05a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246baa0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246c554-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246cf68-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246d936-3db6-11ed-ba35-88d7f641cbef> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/ddc5a250-da82-4102-a47e-9f97c2ff6881> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/623edc68-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623ee6f4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623ef1b2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623efc20-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f0648-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f1066-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f1b7e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62416500-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62416e42-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62417798-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62418116-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62418abc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624194bc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62419ef8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243fd6a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624406de-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624630bc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624639a4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62488c18-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624896ea-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248a180-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ae88c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624af19c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624afda4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d4a46-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d543c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d5e3c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624fc4f6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624fcf00-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624fd8ce-3db6-11ed-ba35-88d7f641cbef> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/98a3acec-51f2-4b6a-a1e1-6b6166d80d2e> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/13842fbc-441c-46ca-a58d-f78a64eb8a93>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623ec836-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623ed222-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6241518c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62415aec-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243dff6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243ea28-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243f342-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246147e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62461e38-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6246275c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62486c4c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62487728-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62488132-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624acd20-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ad630-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624adf68-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d2ab6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d36be-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d40dc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624fa642-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624fb056-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624fbaa6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62520dc4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62521940-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62522340-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625421ae-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62542c30-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6254377a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/bc15da36-a7a3-46eb-9af6-d6a8a12b0ad1>,
+        <http://themis.vlaanderen.be/id/beleidsveld/e4dab90c-bb3a-47c5-abfc-802ddb55480d> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/a41f29a9-7781-4419-a821-fd3bd183c7ba> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/5de93340-ce1a-4886-8425-6c80bbe0351b>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623ea950-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623eb40e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623ebee0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62412fea-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62413a9e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62414656-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243c016-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243ca3e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243d47a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245f89a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624601e6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62460b0a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62484c30-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248564e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624861e8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ab1aa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624abae2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ac41a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d0bda-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d1616-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d1fee-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f86d0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f90f8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f9bde-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6251efe2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6251f9ba-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625203ce-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62540412-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62540e12-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625417ae-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/9bae7bf3-3851-4447-b457-5af1b0c82925>,
+        <http://themis.vlaanderen.be/id/beleidsveld/c08ccb06-460f-4bb7-87d5-714a94c5186b> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/496f03b0-6582-4cfc-97b7-150a276d684f> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/624023ac-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240302c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62403aa4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624044e0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242adb6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242b7e8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242c29c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242cd5a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244fb8e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62450494-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62450e1c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624517fe-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62473c6e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247465a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247503c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62475b04-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249a4a4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249ae04-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249b78c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249c1aa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c0186-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c0ab4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c1414-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c1d2e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e6e8a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e77ae-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e8104-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e8afa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6250e624-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6250efde-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6250fa24-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62510410-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253242a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62532e0c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62533834-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62534266-3db6-11ed-ba35-88d7f641cbef> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/58c91fe9-8839-4653-9693-9a7df6885c06> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/10d5f8a5-3dfe-4661-b6a2-c2ca98f819a3>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d693c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d7576-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d803e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623d8c64-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623ff7e2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240026e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62400eda-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62401952-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62428e8a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62429880-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242a384-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244de7e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244e8a6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244f24c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62471cca-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247274c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62473232-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62498906-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249923e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62499b3a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624be5ac-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624bef34-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624bf858-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e52b0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e5c10-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e6552-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6250c6bc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6250d0f8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6250dbde-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252f8ec-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62530382-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62530f58-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62531a66-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/80106fa7-3f9d-4313-b3e1-040bf0e07410>,
+        <http://themis.vlaanderen.be/id/beleidsveld/998b165e-3c6d-4722-bd1f-af3de421628e>,
+        <http://themis.vlaanderen.be/id/beleidsveld/da9202a5-c504-4f2c-8865-055cf472b3e4> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/e2ccf3f9-6b1f-4b32-9e76-501999c51788> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/106408c9-ec8e-42cf-9e8e-6a8e7ef537b1>,
+        <http://themis.vlaanderen.be/id/beleidsveld/581845a0-0a25-4e43-89d6-7863572aeb6c>,
+        <http://themis.vlaanderen.be/id/beleidsveld/5a9c8b50-1d07-4bcb-9dd8-f1d041437a46>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623dc36e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623dce0e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623dd8cc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623de4a2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623def92-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62404f44-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624059e4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62406470-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62406ec0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624079c4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242d75a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242e1be-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242ed30-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6242f7f8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624521f4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62452c3a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245370c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62454260-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624765c2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62476fc2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247799a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247850c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249cc54-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249d636-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249e04a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249ea54-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c2634-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c3246-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c3da4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c4916-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e940a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e9d2e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ea666-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624eb034-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62510dd4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62511806-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62512328-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62512e5e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62534c70-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62535634-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62536070-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62536a84-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/890bcc01-a3f2-40de-954b-92ea3d958784> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/cb105245-de9e-4d32-8ef9-519b832ed4f9> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/148a2622-b159-4bf7-b6f2-0ec8a5ce2194>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623dfaaa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e0554-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e10a8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e1b34-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240850e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62408fcc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62409a44-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240a520-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624301ee-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62430c20-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624316fc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243225a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62432c5a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62454cba-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624555e8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62455f2a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62456984-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624572a8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624791aa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62479cae-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247a6fe-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247b14e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247bb58-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249f4b8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249ffda-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a09a8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a17fe-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a2208-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c5384-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c5c76-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c65f4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c7148-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c7b20-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624eb980-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ec2ae-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ecde4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ed8ca-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ee482-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625138d6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62514268-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62514c9a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625155d2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62515f14-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62537466-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62537e66-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253888e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62539356-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/b2cdd186-bced-41af-9533-7e234996f16e>,
+        <http://themis.vlaanderen.be/id/beleidsveld/cd9b9d89-5757-448d-a887-10acfc67adfb>,
+        <http://themis.vlaanderen.be/id/beleidsveld/eddfc369-3b67-45a1-b0a2-d527a03c1ce1> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/be302e1b-f4d8-4212-a67d-bf992e6effcf> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/3ada201d-68dd-41a3-b0da-5a8ef27de879>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f2844-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f3320-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f3d7a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f491e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623f6d90-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6241a97a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6241b438-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6241be92-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6241c86a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6241d7b0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244103e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624419bc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6244234e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62442cc2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624436d6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624642be-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62464c64-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62465588-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62465ec0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624667d0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248aa9a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248b3fa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248bdc8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248c6ce-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248cfe8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b0844-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b115e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b1ad2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b23ce-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b2e1e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d6864-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d732c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d7e1c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d88d0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624d91c2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624fe2ce-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624fecec-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ff71e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62500128-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62500b78-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62522c78-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252363c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62524032-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62524a6e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252554a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62544210-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62544be8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62545642-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62546042-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62546a2e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/8f23ea03-637f-4d4b-8135-7281a6358ab1>,
+        <http://themis.vlaanderen.be/id/beleidsveld/a84f868d-de05-4a62-b7eb-fc676479a6d2>,
+        <http://themis.vlaanderen.be/id/beleidsveld/b5eb0138-b286-473e-8f06-5647db7ac120>,
+        <http://themis.vlaanderen.be/id/beleidsveld/d5193292-bdc1-4c7d-ba0a-661219108801> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/82535aaf-39ec-4b31-a181-f44241a65c93> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/114e5c23-e495-41b7-995c-bc390b5234a0>,
+        <http://themis.vlaanderen.be/id/beleidsveld/19c1626d-1172-48f9-81d7-368015eb3489>,
+        <http://themis.vlaanderen.be/id/beleidsveld/4fbef468-55dd-4191-96bd-e0ac9e28aa91>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e68fa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e73ae-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e7e3a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e8894-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e92ee-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e9d5c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240f106-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240fb60-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62410588-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62410fce-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62411bae-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624125e0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62437f84-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62438a56-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624394f6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62439eec-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243a914-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243b5c6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245c000-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245c938-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245d284-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245dbbc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245e4b8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245edd2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62480e46-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62481846-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62482318-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62482d4a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62483790-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248421c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a7348-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a7d66-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a87de-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a9378-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a9db4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624aa70a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ccd5a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624cd840-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ce376-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ceccc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624cf622-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624cffaa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f42d8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f4e18-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f5962-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f6484-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f717c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f7cda-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6251b0a4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6251bc2a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6251c710-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6251d0de-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6251dba6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6251e592-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253dbc2-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253e5a4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253efae-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253f9b8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/fc405ce9-5535-440d-a121-5deacab67d28> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/8aefc421-830d-4eb8-a302-6649d346414f> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/6248f9e6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249042c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62490ecc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624918cc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624922d6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62492e8e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249397e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249434c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62494ce8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249576a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624962c8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62496c0a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6249756a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62497eac-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b57d6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b61b8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b6bcc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b7612-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b8008-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b8a44-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b9462-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624b9f20-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ba902-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624bb30c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624bbcda-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624bc720-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624bd22e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624bdcc4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624dc836-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624dd236-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ddc2c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624de794-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624df27a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624dfd88-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e06ca-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e10fc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e1a02-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e231c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e2c22-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e35c8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e405e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624e4964-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62503594-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62503fda-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625049da-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625053e4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62505e16-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6250682a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62507234-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62507d4c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625087b0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625091c4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62509c50-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6250a740-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6250b29e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6250bca8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62529d02-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252a69e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252b17a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252bc4c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252c64c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252d074-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252da9c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252e47e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6252ef0a-3db6-11ed-ba35-88d7f641cbef> .
+
+<http://themis.vlaanderen.be/id/beleidsdomein/53af66e3-b055-4a74-9f24-03ea9def4e0c> skos:narrower <http://themis.vlaanderen.be/id/beleidsveld/08249005-75e6-4791-ac7f-dbbb3a4d79c4>,
+        <http://themis.vlaanderen.be/id/beleidsveld/2731fdbe-592b-414c-8675-22a7b9d7b3bc>,
+        <http://themis.vlaanderen.be/id/beleidsveld/4cd5d9d1-099b-437e-be1a-99c069469fcb>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e2746-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e329a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e3eb6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e491a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e5392-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/623e5e64-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240b0c4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240baf6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240c708-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240d31a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240dc8e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6240e684-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62433650-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243414a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62434bd6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624355d6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6243603a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62436a76-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62437566-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62457be0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624585cc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62458f0e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62459850-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245a174-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245ad72-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6245b6a0-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247c6de-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247d138-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247dafc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247e4fc-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247ef10-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6247f9ec-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6248040a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a2c30-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a3644-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a408a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a4a8a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a5430-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a5e58-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624a6902-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c85b6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c9088-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624c9aba-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ca4d8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624caf3c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624cb914-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624cc364-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624eee32-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624ef77e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f00b6-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f09ee-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f12f4-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f1c22-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/624f38ce-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62516874-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625172ba-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62517d1e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6251876e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/625191aa-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62519c90-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6251a6b8-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/62539e8c-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253a882-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253b282-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253bd40-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253c75e-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/6253d14a-3db6-11ed-ba35-88d7f641cbef>,
+        <http://themis.vlaanderen.be/id/beleidsveld/72b6fc10-b729-40f3-9c03-9f7d55e076a7>,
+        <http://themis.vlaanderen.be/id/beleidsveld/82208ea2-8371-4ed1-906f-5ae4c101caee>,
+        <http://themis.vlaanderen.be/id/beleidsveld/d83bfbfd-5821-4cf3-85cc-c7201f9343a6> .

--- a/config/migrations/20220926140003-beleidsvelden-themis-concepts-migratie.sparql
+++ b/config/migrations/20220926140003-beleidsvelden-themis-concepts-migratie.sparql
@@ -1,4 +1,5 @@
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 DELETE {
   GRAPH ?g {
@@ -71,6 +72,7 @@ WHERE {
     ?oldGovernmentField ?p ?o .
     ?oldGovernmentField skos:prefLabel ?oldLabel .
     FILTER (?p != skos:prefLabel)
+    FILTER (?p != rdf:type)
   }
 }
 

--- a/config/migrations/20220926140003-beleidsvelden-themis-concepts-migratie.sparql
+++ b/config/migrations/20220926140003-beleidsvelden-themis-concepts-migratie.sparql
@@ -1,0 +1,148 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH ?g {
+    ?oldGovernmentField ?p ?o .
+    ?oldGovernmentField skos:prefLabel ?oldLabel .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?newGovernmentField ?p ?o .
+  }
+}
+WHERE {
+  VALUES (?oldGovernmentField ?newGovernmentField) {
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/01f64f4e-d435-4f98-8260-7e1843bf1555> <http://themis.vlaanderen.be/id/beleidsveld/01f64f4e-d435-4f98-8260-7e1843bf1555>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/0db685d1-811f-49f9-a6fe-348aab08bba4> <http://themis.vlaanderen.be/id/beleidsveld/0db685d1-811f-49f9-a6fe-348aab08bba4>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/52e877e2-d342-4b0c-9835-74368a296d6c> <http://themis.vlaanderen.be/id/beleidsveld/52e877e2-d342-4b0c-9835-74368a296d6c>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/ff815ebf-7a96-42be-90fc-88824854e6a6> <http://themis.vlaanderen.be/id/beleidsveld/ff815ebf-7a96-42be-90fc-88824854e6a6>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/624264fe-0e06-48c1-9e97-eeb4089f5971> <http://themis.vlaanderen.be/id/beleidsveld/624264fe-0e06-48c1-9e97-eeb4089f5971>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/0f693798-541d-49ee-b705-4643661402a2> <http://themis.vlaanderen.be/id/beleidsveld/0f693798-541d-49ee-b705-4643661402a2>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/82883c33-57c8-4e67-9669-53ef7f960b51> <http://themis.vlaanderen.be/id/beleidsveld/82883c33-57c8-4e67-9669-53ef7f960b51>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/32c9b7d9-6fe5-4e68-bd4f-0f895fadeb4c> <http://themis.vlaanderen.be/id/beleidsveld/32c9b7d9-6fe5-4e68-bd4f-0f895fadeb4c>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2> <http://themis.vlaanderen.be/id/beleidsveld/1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/4d73b772-ccfa-4bd8-bd45-6722b1972a1a> <http://themis.vlaanderen.be/id/beleidsveld/4d73b772-ccfa-4bd8-bd45-6722b1972a1a>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/64634310-4c8d-46a3-ac4a-e7777a434729> <http://themis.vlaanderen.be/id/beleidsveld/64634310-4c8d-46a3-ac4a-e7777a434729>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/59e231ce-97d2-4576-a152-c2807eefa5b6> <http://themis.vlaanderen.be/id/beleidsveld/59e231ce-97d2-4576-a152-c2807eefa5b6>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/35d0740c-2754-4ca3-a334-936401383bcf> <http://themis.vlaanderen.be/id/beleidsveld/35d0740c-2754-4ca3-a334-936401383bcf>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/e4d93deb-7e21-4838-b83d-da6b8c562723> <http://themis.vlaanderen.be/id/beleidsveld/e4d93deb-7e21-4838-b83d-da6b8c562723>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/80106fa7-3f9d-4313-b3e1-040bf0e07410> <http://themis.vlaanderen.be/id/beleidsveld/80106fa7-3f9d-4313-b3e1-040bf0e07410>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/da9202a5-c504-4f2c-8865-055cf472b3e4> <http://themis.vlaanderen.be/id/beleidsveld/da9202a5-c504-4f2c-8865-055cf472b3e4>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/10d5f8a5-3dfe-4661-b6a2-c2ca98f819a3> <http://themis.vlaanderen.be/id/beleidsveld/10d5f8a5-3dfe-4661-b6a2-c2ca98f819a3>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/998b165e-3c6d-4722-bd1f-af3de421628e> <http://themis.vlaanderen.be/id/beleidsveld/998b165e-3c6d-4722-bd1f-af3de421628e>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/581845a0-0a25-4e43-89d6-7863572aeb6c> <http://themis.vlaanderen.be/id/beleidsveld/581845a0-0a25-4e43-89d6-7863572aeb6c>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/5a9c8b50-1d07-4bcb-9dd8-f1d041437a46> <http://themis.vlaanderen.be/id/beleidsveld/5a9c8b50-1d07-4bcb-9dd8-f1d041437a46>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/890bcc01-a3f2-40de-954b-92ea3d958784> <http://themis.vlaanderen.be/id/beleidsveld/890bcc01-a3f2-40de-954b-92ea3d958784>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/106408c9-ec8e-42cf-9e8e-6a8e7ef537b1> <http://themis.vlaanderen.be/id/beleidsveld/106408c9-ec8e-42cf-9e8e-6a8e7ef537b1>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/eddfc369-3b67-45a1-b0a2-d527a03c1ce1> <http://themis.vlaanderen.be/id/beleidsveld/eddfc369-3b67-45a1-b0a2-d527a03c1ce1>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/b2cdd186-bced-41af-9533-7e234996f16e> <http://themis.vlaanderen.be/id/beleidsveld/b2cdd186-bced-41af-9533-7e234996f16e>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/cd9b9d89-5757-448d-a887-10acfc67adfb> <http://themis.vlaanderen.be/id/beleidsveld/cd9b9d89-5757-448d-a887-10acfc67adfb>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/148a2622-b159-4bf7-b6f2-0ec8a5ce2194> <http://themis.vlaanderen.be/id/beleidsveld/148a2622-b159-4bf7-b6f2-0ec8a5ce2194>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/82208ea2-8371-4ed1-906f-5ae4c101caee> <http://themis.vlaanderen.be/id/beleidsveld/82208ea2-8371-4ed1-906f-5ae4c101caee>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/d83bfbfd-5821-4cf3-85cc-c7201f9343a6> <http://themis.vlaanderen.be/id/beleidsveld/d83bfbfd-5821-4cf3-85cc-c7201f9343a6>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/08249005-75e6-4791-ac7f-dbbb3a4d79c4> <http://themis.vlaanderen.be/id/beleidsveld/08249005-75e6-4791-ac7f-dbbb3a4d79c4>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/72b6fc10-b729-40f3-9c03-9f7d55e076a7> <http://themis.vlaanderen.be/id/beleidsveld/72b6fc10-b729-40f3-9c03-9f7d55e076a7>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/4cd5d9d1-099b-437e-be1a-99c069469fcb> <http://themis.vlaanderen.be/id/beleidsveld/4cd5d9d1-099b-437e-be1a-99c069469fcb>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/2731fdbe-592b-414c-8675-22a7b9d7b3bc> <http://themis.vlaanderen.be/id/beleidsveld/2731fdbe-592b-414c-8675-22a7b9d7b3bc>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/fc405ce9-5535-440d-a121-5deacab67d28> <http://themis.vlaanderen.be/id/beleidsveld/fc405ce9-5535-440d-a121-5deacab67d28>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/19c1626d-1172-48f9-81d7-368015eb3489> <http://themis.vlaanderen.be/id/beleidsveld/19c1626d-1172-48f9-81d7-368015eb3489>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/4fbef468-55dd-4191-96bd-e0ac9e28aa91> <http://themis.vlaanderen.be/id/beleidsveld/4fbef468-55dd-4191-96bd-e0ac9e28aa91>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/114e5c23-e495-41b7-995c-bc390b5234a0> <http://themis.vlaanderen.be/id/beleidsveld/114e5c23-e495-41b7-995c-bc390b5234a0>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/9bae7bf3-3851-4447-b457-5af1b0c82925> <http://themis.vlaanderen.be/id/beleidsveld/9bae7bf3-3851-4447-b457-5af1b0c82925>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/c08ccb06-460f-4bb7-87d5-714a94c5186b> <http://themis.vlaanderen.be/id/beleidsveld/c08ccb06-460f-4bb7-87d5-714a94c5186b>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/5de93340-ce1a-4886-8425-6c80bbe0351b> <http://themis.vlaanderen.be/id/beleidsveld/5de93340-ce1a-4886-8425-6c80bbe0351b>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/e4dab90c-bb3a-47c5-abfc-802ddb55480d> <http://themis.vlaanderen.be/id/beleidsveld/e4dab90c-bb3a-47c5-abfc-802ddb55480d>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/bc15da36-a7a3-46eb-9af6-d6a8a12b0ad1> <http://themis.vlaanderen.be/id/beleidsveld/bc15da36-a7a3-46eb-9af6-d6a8a12b0ad1>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/13842fbc-441c-46ca-a58d-f78a64eb8a93> <http://themis.vlaanderen.be/id/beleidsveld/13842fbc-441c-46ca-a58d-f78a64eb8a93>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/d5193292-bdc1-4c7d-ba0a-661219108801> <http://themis.vlaanderen.be/id/beleidsveld/d5193292-bdc1-4c7d-ba0a-661219108801>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/8f23ea03-637f-4d4b-8135-7281a6358ab1> <http://themis.vlaanderen.be/id/beleidsveld/8f23ea03-637f-4d4b-8135-7281a6358ab1>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/b5eb0138-b286-473e-8f06-5647db7ac120> <http://themis.vlaanderen.be/id/beleidsveld/b5eb0138-b286-473e-8f06-5647db7ac120>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/a84f868d-de05-4a62-b7eb-fc676479a6d2> <http://themis.vlaanderen.be/id/beleidsveld/a84f868d-de05-4a62-b7eb-fc676479a6d2>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/3ada201d-68dd-41a3-b0da-5a8ef27de879> <http://themis.vlaanderen.be/id/beleidsveld/3ada201d-68dd-41a3-b0da-5a8ef27de879>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/c48135d7-f235-460a-af3b-deb3954e6a32> <http://themis.vlaanderen.be/id/beleidsveld/c48135d7-f235-460a-af3b-deb3954e6a32>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/d1b93810-6066-4b0e-ad31-130c7ae838ac> <http://themis.vlaanderen.be/id/beleidsveld/d1b93810-6066-4b0e-ad31-130c7ae838ac>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/d185e71b-2a6f-49e5-b710-3d9f58ddf11b> <http://themis.vlaanderen.be/id/beleidsveld/d185e71b-2a6f-49e5-b710-3d9f58ddf11b>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/ea4c45da-a07d-49c9-92ab-16d0a0d4e37e> <http://themis.vlaanderen.be/id/beleidsveld/ea4c45da-a07d-49c9-92ab-16d0a0d4e37e>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/43b8de2e-61f9-4cf8-a018-9f3cc27f4103> <http://themis.vlaanderen.be/id/beleidsveld/43b8de2e-61f9-4cf8-a018-9f3cc27f4103>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/2b0103aa-a3e8-4718-80f8-8de405966c57> <http://themis.vlaanderen.be/id/beleidsveld/2b0103aa-a3e8-4718-80f8-8de405966c57>)
+  }
+  GRAPH ?g {
+    ?oldGovernmentField ?p ?o .
+    ?oldGovernmentField skos:prefLabel ?oldLabel .
+    FILTER (?p != skos:prefLabel)
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?oldGovernmentField .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s ?p ?newGovernmentField .
+  }
+}
+WHERE {
+  VALUES (?oldGovernmentField ?newGovernmentField) {
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/01f64f4e-d435-4f98-8260-7e1843bf1555> <http://themis.vlaanderen.be/id/beleidsveld/01f64f4e-d435-4f98-8260-7e1843bf1555>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/0db685d1-811f-49f9-a6fe-348aab08bba4> <http://themis.vlaanderen.be/id/beleidsveld/0db685d1-811f-49f9-a6fe-348aab08bba4>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/52e877e2-d342-4b0c-9835-74368a296d6c> <http://themis.vlaanderen.be/id/beleidsveld/52e877e2-d342-4b0c-9835-74368a296d6c>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/ff815ebf-7a96-42be-90fc-88824854e6a6> <http://themis.vlaanderen.be/id/beleidsveld/ff815ebf-7a96-42be-90fc-88824854e6a6>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/624264fe-0e06-48c1-9e97-eeb4089f5971> <http://themis.vlaanderen.be/id/beleidsveld/624264fe-0e06-48c1-9e97-eeb4089f5971>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/0f693798-541d-49ee-b705-4643661402a2> <http://themis.vlaanderen.be/id/beleidsveld/0f693798-541d-49ee-b705-4643661402a2>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/82883c33-57c8-4e67-9669-53ef7f960b51> <http://themis.vlaanderen.be/id/beleidsveld/82883c33-57c8-4e67-9669-53ef7f960b51>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/32c9b7d9-6fe5-4e68-bd4f-0f895fadeb4c> <http://themis.vlaanderen.be/id/beleidsveld/32c9b7d9-6fe5-4e68-bd4f-0f895fadeb4c>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2> <http://themis.vlaanderen.be/id/beleidsveld/1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/4d73b772-ccfa-4bd8-bd45-6722b1972a1a> <http://themis.vlaanderen.be/id/beleidsveld/4d73b772-ccfa-4bd8-bd45-6722b1972a1a>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/64634310-4c8d-46a3-ac4a-e7777a434729> <http://themis.vlaanderen.be/id/beleidsveld/64634310-4c8d-46a3-ac4a-e7777a434729>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/59e231ce-97d2-4576-a152-c2807eefa5b6> <http://themis.vlaanderen.be/id/beleidsveld/59e231ce-97d2-4576-a152-c2807eefa5b6>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/35d0740c-2754-4ca3-a334-936401383bcf> <http://themis.vlaanderen.be/id/beleidsveld/35d0740c-2754-4ca3-a334-936401383bcf>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/e4d93deb-7e21-4838-b83d-da6b8c562723> <http://themis.vlaanderen.be/id/beleidsveld/e4d93deb-7e21-4838-b83d-da6b8c562723>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/80106fa7-3f9d-4313-b3e1-040bf0e07410> <http://themis.vlaanderen.be/id/beleidsveld/80106fa7-3f9d-4313-b3e1-040bf0e07410>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/da9202a5-c504-4f2c-8865-055cf472b3e4> <http://themis.vlaanderen.be/id/beleidsveld/da9202a5-c504-4f2c-8865-055cf472b3e4>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/10d5f8a5-3dfe-4661-b6a2-c2ca98f819a3> <http://themis.vlaanderen.be/id/beleidsveld/10d5f8a5-3dfe-4661-b6a2-c2ca98f819a3>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/998b165e-3c6d-4722-bd1f-af3de421628e> <http://themis.vlaanderen.be/id/beleidsveld/998b165e-3c6d-4722-bd1f-af3de421628e>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/581845a0-0a25-4e43-89d6-7863572aeb6c> <http://themis.vlaanderen.be/id/beleidsveld/581845a0-0a25-4e43-89d6-7863572aeb6c>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/5a9c8b50-1d07-4bcb-9dd8-f1d041437a46> <http://themis.vlaanderen.be/id/beleidsveld/5a9c8b50-1d07-4bcb-9dd8-f1d041437a46>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/890bcc01-a3f2-40de-954b-92ea3d958784> <http://themis.vlaanderen.be/id/beleidsveld/890bcc01-a3f2-40de-954b-92ea3d958784>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/106408c9-ec8e-42cf-9e8e-6a8e7ef537b1> <http://themis.vlaanderen.be/id/beleidsveld/106408c9-ec8e-42cf-9e8e-6a8e7ef537b1>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/eddfc369-3b67-45a1-b0a2-d527a03c1ce1> <http://themis.vlaanderen.be/id/beleidsveld/eddfc369-3b67-45a1-b0a2-d527a03c1ce1>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/b2cdd186-bced-41af-9533-7e234996f16e> <http://themis.vlaanderen.be/id/beleidsveld/b2cdd186-bced-41af-9533-7e234996f16e>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/cd9b9d89-5757-448d-a887-10acfc67adfb> <http://themis.vlaanderen.be/id/beleidsveld/cd9b9d89-5757-448d-a887-10acfc67adfb>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/148a2622-b159-4bf7-b6f2-0ec8a5ce2194> <http://themis.vlaanderen.be/id/beleidsveld/148a2622-b159-4bf7-b6f2-0ec8a5ce2194>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/82208ea2-8371-4ed1-906f-5ae4c101caee> <http://themis.vlaanderen.be/id/beleidsveld/82208ea2-8371-4ed1-906f-5ae4c101caee>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/d83bfbfd-5821-4cf3-85cc-c7201f9343a6> <http://themis.vlaanderen.be/id/beleidsveld/d83bfbfd-5821-4cf3-85cc-c7201f9343a6>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/08249005-75e6-4791-ac7f-dbbb3a4d79c4> <http://themis.vlaanderen.be/id/beleidsveld/08249005-75e6-4791-ac7f-dbbb3a4d79c4>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/72b6fc10-b729-40f3-9c03-9f7d55e076a7> <http://themis.vlaanderen.be/id/beleidsveld/72b6fc10-b729-40f3-9c03-9f7d55e076a7>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/4cd5d9d1-099b-437e-be1a-99c069469fcb> <http://themis.vlaanderen.be/id/beleidsveld/4cd5d9d1-099b-437e-be1a-99c069469fcb>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/2731fdbe-592b-414c-8675-22a7b9d7b3bc> <http://themis.vlaanderen.be/id/beleidsveld/2731fdbe-592b-414c-8675-22a7b9d7b3bc>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/fc405ce9-5535-440d-a121-5deacab67d28> <http://themis.vlaanderen.be/id/beleidsveld/fc405ce9-5535-440d-a121-5deacab67d28>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/19c1626d-1172-48f9-81d7-368015eb3489> <http://themis.vlaanderen.be/id/beleidsveld/19c1626d-1172-48f9-81d7-368015eb3489>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/4fbef468-55dd-4191-96bd-e0ac9e28aa91> <http://themis.vlaanderen.be/id/beleidsveld/4fbef468-55dd-4191-96bd-e0ac9e28aa91>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/114e5c23-e495-41b7-995c-bc390b5234a0> <http://themis.vlaanderen.be/id/beleidsveld/114e5c23-e495-41b7-995c-bc390b5234a0>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/9bae7bf3-3851-4447-b457-5af1b0c82925> <http://themis.vlaanderen.be/id/beleidsveld/9bae7bf3-3851-4447-b457-5af1b0c82925>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/c08ccb06-460f-4bb7-87d5-714a94c5186b> <http://themis.vlaanderen.be/id/beleidsveld/c08ccb06-460f-4bb7-87d5-714a94c5186b>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/5de93340-ce1a-4886-8425-6c80bbe0351b> <http://themis.vlaanderen.be/id/beleidsveld/5de93340-ce1a-4886-8425-6c80bbe0351b>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/e4dab90c-bb3a-47c5-abfc-802ddb55480d> <http://themis.vlaanderen.be/id/beleidsveld/e4dab90c-bb3a-47c5-abfc-802ddb55480d>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/bc15da36-a7a3-46eb-9af6-d6a8a12b0ad1> <http://themis.vlaanderen.be/id/beleidsveld/bc15da36-a7a3-46eb-9af6-d6a8a12b0ad1>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/13842fbc-441c-46ca-a58d-f78a64eb8a93> <http://themis.vlaanderen.be/id/beleidsveld/13842fbc-441c-46ca-a58d-f78a64eb8a93>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/d5193292-bdc1-4c7d-ba0a-661219108801> <http://themis.vlaanderen.be/id/beleidsveld/d5193292-bdc1-4c7d-ba0a-661219108801>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/8f23ea03-637f-4d4b-8135-7281a6358ab1> <http://themis.vlaanderen.be/id/beleidsveld/8f23ea03-637f-4d4b-8135-7281a6358ab1>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/b5eb0138-b286-473e-8f06-5647db7ac120> <http://themis.vlaanderen.be/id/beleidsveld/b5eb0138-b286-473e-8f06-5647db7ac120>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/a84f868d-de05-4a62-b7eb-fc676479a6d2> <http://themis.vlaanderen.be/id/beleidsveld/a84f868d-de05-4a62-b7eb-fc676479a6d2>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/3ada201d-68dd-41a3-b0da-5a8ef27de879> <http://themis.vlaanderen.be/id/beleidsveld/3ada201d-68dd-41a3-b0da-5a8ef27de879>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/c48135d7-f235-460a-af3b-deb3954e6a32> <http://themis.vlaanderen.be/id/beleidsveld/c48135d7-f235-460a-af3b-deb3954e6a32>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/d1b93810-6066-4b0e-ad31-130c7ae838ac> <http://themis.vlaanderen.be/id/beleidsveld/d1b93810-6066-4b0e-ad31-130c7ae838ac>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/d185e71b-2a6f-49e5-b710-3d9f58ddf11b> <http://themis.vlaanderen.be/id/beleidsveld/d185e71b-2a6f-49e5-b710-3d9f58ddf11b>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/ea4c45da-a07d-49c9-92ab-16d0a0d4e37e> <http://themis.vlaanderen.be/id/beleidsveld/ea4c45da-a07d-49c9-92ab-16d0a0d4e37e>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/43b8de2e-61f9-4cf8-a018-9f3cc27f4103> <http://themis.vlaanderen.be/id/beleidsveld/43b8de2e-61f9-4cf8-a018-9f3cc27f4103>)
+    (<http://kanselarij.vo.data.gift/id/beleidsveld/2b0103aa-a3e8-4718-80f8-8de405966c57> <http://themis.vlaanderen.be/id/beleidsveld/2b0103aa-a3e8-4718-80f8-8de405966c57>)
+  }
+  GRAPH ?g {
+    ?s ?p ?oldGovernmentField .
+  }
+}

--- a/config/migrations/20220929134700-remove-ext-beleidsveld-rdf-type.sparql
+++ b/config/migrations/20220929134700-remove-ext-beleidsveld-rdf-type.sparql
@@ -1,0 +1,13 @@
+DELETE WHERE {
+  GRAPH ?g {
+    ?s a <http://mu.semte.ch/vocabularies/ext/Beleidsveld> .
+  }
+}
+
+;
+
+DELETE WHERE {
+  GRAPH ?g {
+    ?s a <http://mu.semte.ch/vocabularies/ext/Beleidsdomein> .
+  }
+}

--- a/config/resources/concept-domain.json
+++ b/config/resources/concept-domain.json
@@ -27,6 +27,14 @@
         "position": {
           "type": "integer",
           "predicate": "schema:position"
+        },
+        "start-date": {
+          "type": "datetime",
+          "predicate": "prov:generatedAtTime"
+        },
+        "end-date": {
+          "type": "datetime",
+          "predicate": "prov:invalidatedAtTime"
         }
       },
       "relationships": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -313,7 +313,7 @@ services:
     labels:
       - "logging=true"
   publication-report:
-    image: kanselarij/publication-report-service:0.3.0
+    image: kanselarij/publication-report-service:0.4.0
     volumes:
       - ./data/files:/share
     environment:


### PR DESCRIPTION
https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1487
https://github.com/kanselarij-vlaanderen/publication-report-service/pull/5

Adds triples for all government domains and -fields that have been in use since 2006 and migrates existing government {domains,fields} to the newly added resources.

Also fixes two incorrect URIs (that used `/id/concept-schema` instead of `/id/concept-scheme`).

Custom Jenkins run: http://kal-kastaar.s.redpencil.io:8080/job/kaleidos/job/custom_frontend_backend_combination_2/47/