### PR TITLE
KAS-3576: migrate provisional government areas

### DIFF
--- a/config/migrations/20220927142303-migrate-pubflow-provisoir-government-areas.sparql
+++ b/config/migrations/20220927142303-migrate-pubflow-provisoir-government-areas.sparql
@@ -1,0 +1,34 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+
+DELETE {
+  GRAPH ?g {
+    ?publicationFlow <http://mu.semte.ch/vocabularies/ext/publicatie/beleidsdomein#provisioir> ?governmentArea.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?decisionFlow besluitvorming:beleidsveld ?governmentArea .
+    ?subcase besluitvorming:beleidsveld ?governmentArea .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?publicationFlow a pub:Publicatieaangelegenheid .
+    ?publicationFlow <http://mu.semte.ch/vocabularies/ext/publicatie/beleidsdomein#provisioir> ?governmentArea.
+
+    ?publicationFlow dossier:behandelt ?case .
+    ?case dossier:Dossier.isNeerslagVan ?decisionFlow .
+    ?decisionFlow dossier:doorloopt ?subcase .
+
+    # Filter so that we only get the latest subcase
+    ?subcase dct:created ?created .
+    FILTER NOT EXISTS {
+      ?decisionFlow dossier:doorloopt ?subcase_ .
+      ?subcase_ dct:created ?created_ .
+      FILTER(?created_ > ?created)
+    }
+  }
+}


### PR DESCRIPTION
The scope of this PR is somewhat smaller than described in the ticket. There was no mapping necessary between a publication flow's "provisional" government area and the actual governmeant area's that we have in the database. The triples already pointed to valid government areas, specifically government domains, and since those don't change over time no extra mapping was necessary based on publication flow creation date.

What was changed is the removal of the provisional government areas. These `?pubflow pub:beleidsdomein#provisioir ?governmentArea` triples were removed and in their place the government area have been added to the respective decisionmaking-flows and subcases.