### PR TITLE
KAS-3609: Users code cleanup

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -292,10 +292,6 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/alerts/"
   end
 
-  match "/user-management/*path", @json_service do
-    Proxy.forward conn, path, "http://user-management/"
-  end
-
   match "/alert-types/*path", @json_service do
     Proxy.forward conn, path, "http://cache/alert-types"
   end

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -80,8 +80,6 @@ services:
   newsletter:
     entrypoint: "echo 'service disabled'"
     restart: "no"
-  user-management:
-    restart: "no"
   yggdrasil:
     restart: "no"
   sink:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -104,18 +104,18 @@ services:
     entrypoint: "echo 'service disabled'"
     restart: "no"
   staatsblad-uuid-generation:
-    entrypoint: "echo 'service disabled'"
+    image: lblod/sink-service:1.0.0
     restart: "no"
   staatsblad-scraping:
     entrypoint: "echo 'service disabled'"
     restart: "no"
   staatsblad-linking:
-    entrypoint: "echo 'service disabled'"
+    image: lblod/sink-service:1.0.0
     restart: "no"
   publication-report:
     restart: "no"
   delta-producer:
-    entrypoint: "echo 'service disabled'"
+    image: lblod/sink-service:1.0.0
     restart: "no"
   fileshare:
     entrypoint: "echo 'service disabled'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,14 +187,6 @@ services:
     restart: always
     labels:
       - "logging=true"
-  user-management:
-    image: kanselarij/user-management-service:1.1.0
-    environment:
-      MU_APPLICATION_RESOURCE_BASE_URI: "http://themis.vlaanderen.be/"
-    logging: *default-logging
-    restart: always
-    labels:
-      - "logging=true"
   yggdrasil:
     image: kanselarij/yggdrasil:5.9.0
     logging: *default-logging


### PR DESCRIPTION
# :warning: This PR merges into #325 
Either merge this one before merging the parent PR, or change the base branch.

Removes references to user-management-service and sets some delta-consuming services as sinks in `docker-compose.development.yml`.