### PR TITLE
KAS-3635: Remove duplicate codelists

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -196,6 +196,12 @@ defmodule Acl.UserGroups.Config do
       "http://mu.semte.ch/vocabularies/ext/LoginActivity",
     ]
   end
+  
+  defp system_resource_types() do
+    [
+      "http://mu.semte.ch/vocabularies/ext/SysteemNotificatie",
+    ]
+  end
 
   defp public_static_data() do
     [
@@ -206,7 +212,6 @@ defmodule Acl.UserGroups.Config do
       "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
       "http://www.w3.org/ns/prov#Generation",
       "http://www.w3.org/ns/prov#Invalidation",
-      "http://mu.semte.ch/vocabularies/ext/SysteemNotificatie",
       "http://www.w3.org/ns/org#Organization",
     ]
   end
@@ -248,6 +253,7 @@ defmodule Acl.UserGroups.Config do
             constraint: %ResourceConstraint{
               resource_types: public_static_data() ++
               public_codelists() ++
+              system_resource_types() ++
               user_account_resource_types() # required to list mock accounts for unauthenticated users
             } },
           %GraphSpec{
@@ -290,9 +296,7 @@ defmodule Acl.UserGroups.Config do
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/public",
             constraint: %ResourceConstraint{
-              resource_types: [
-                "http://mu.semte.ch/vocabularies/ext/SysteemNotificatie"
-              ]
+              resource_types: system_resource_types()
             }
           }
         ]

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -197,11 +197,11 @@ defmodule Acl.UserGroups.Config do
     ]
   end
 
-  defp unconfidential_resource_types() do
+  defp public_static_data() do
     [
       "http://data.vlaanderen.be/ns/mandaat#Mandaat",
       "http://data.vlaanderen.be/ns/mandaat#Mandataris",
-      "http://www.w3.org/ns/person#Person",
+      "http://www.w3.org/ns/person#Person", # when used as bestuurlijke-alias-van mandaat:Mandataris
       "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
       "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
       "http://www.w3.org/ns/prov#Generation",
@@ -211,7 +211,7 @@ defmodule Acl.UserGroups.Config do
     ]
   end
 
-  defp static_unconfidential_code_list_types() do
+  defp public_codelists() do
     [
       "http://mu.semte.ch/vocabularies/ext/DocumentTypeCode",
       "http://mu.semte.ch/vocabularies/ext/ThemaCode",
@@ -246,8 +246,8 @@ defmodule Acl.UserGroups.Config do
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/public",
             constraint: %ResourceConstraint{
-              resource_types: unconfidential_resource_types() ++
-              static_unconfidential_code_list_types() ++
+              resource_types: public_static_data() ++
+              public_codelists() ++
               user_account_resource_types() # required to list mock accounts for unauthenticated users
             } },
           %GraphSpec{

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -199,7 +199,6 @@ defmodule Acl.UserGroups.Config do
 
   defp unconfidential_resource_types() do
     [
-      "http://mu.semte.ch/vocabularies/ext/DocumentIdentifier", # TODO: check if this type is in use.
       "http://data.vlaanderen.be/ns/mandaat#Mandaat",
       "http://data.vlaanderen.be/ns/mandaat#Mandataris",
       "http://www.w3.org/ns/person#Person",
@@ -216,10 +215,8 @@ defmodule Acl.UserGroups.Config do
     [
       "http://mu.semte.ch/vocabularies/ext/DocumentTypeCode",
       "http://mu.semte.ch/vocabularies/ext/ThemaCode",
-      "http://mu.semte.ch/vocabularies/ext/Thema", # TODO: check if this type is in use. Looks like only "ThemaCode" is.
       "http://mu.semte.ch/vocabularies/ext/SysteemNotificatieType",
       "http://mu.semte.ch/vocabularies/ext/BeslissingsResultaatCode",
-      "http://mu.semte.ch/vocabularies/ext/DossierTypeCode",
       "http://mu.semte.ch/vocabularies/ext/ProcedurestapType",
       "http://mu.semte.ch/vocabularies/ext/publicatie/Publicatiestatus",
       "http://mu.semte.ch/vocabularies/ext/publicatie/PublicatieWijze",

--- a/config/migrations/20221021080000-remove-duplicated-person-triples.sparql
+++ b/config/migrations/20221021080000-remove-duplicated-person-triples.sparql
@@ -1,0 +1,31 @@
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES (?type) {
+    (person:Person)
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a ?type .
+  }
+  GRAPH ?g {
+    ?s a ?type .
+    ?s ?p ?o .
+  }
+  FILTER (?g != <http://mu.semte.ch/graphs/public>)
+  FILTER EXISTS {
+    [] mandaat:isBestuurlijkeAliasVan ?s .
+  }
+  FILTER EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?s ?p ?o .
+    }
+  }
+}

--- a/config/migrations/20221021080000-remove-duplicated-person-triples.sparql
+++ b/config/migrations/20221021080000-remove-duplicated-person-triples.sparql
@@ -23,9 +23,4 @@ WHERE {
   FILTER EXISTS {
     [] mandaat:isBestuurlijkeAliasVan ?s .
   }
-  FILTER EXISTS {
-    GRAPH <http://mu.semte.ch/graphs/public> {
-      ?s ?p ?o .
-    }
-  }
 }

--- a/config/migrations/20221021094135-remove-duplicated-static-triples.sparql
+++ b/config/migrations/20221021094135-remove-duplicated-static-triples.sparql
@@ -53,9 +53,4 @@ WHERE {
     ?s ?p ?o .
   }
   FILTER (?g != <http://mu.semte.ch/graphs/public>)
-  FILTER EXISTS {
-    GRAPH <http://mu.semte.ch/graphs/public> {
-      ?s ?p ?o .
-    }
-  }
 }

--- a/config/migrations/20221021094135-remove-duplicated-static-triples.sparql
+++ b/config/migrations/20221021094135-remove-duplicated-static-triples.sparql
@@ -1,0 +1,61 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX euvoc: <http://publications.europa.eu/ontology/euvoc#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+# Ignore incoming links. Either they come from another static type, which we will
+# move anyway, or they don't, then we want them to stay in the in their
+# respective graph.
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES (?type) {
+    (ext:DocumentTypeCode)
+    (ext:ThemaCode)
+    (ext:SysteemNotificatieType)
+    (ext:BeslissingsResultaatCode)
+    (ext:ProcedureStapType)
+    (pub:Publicatiestatus)
+    (pub:PublicatieWijze)
+    (pub:Urgentieniveau)
+    (pub:Publicatierapporttype)
+    (ext:RegelgevingType)
+    (euvoc:Language)
+    (org:Role)
+    (skos:Concept)
+    (skos:ConceptScheme)
+    (mandaat:Mandaat)
+    (mandaat:Mandataris)
+    (besluit:Bestuurseenheid)
+    (besluit:Bestuursorgaan)
+    (prov:Generation)
+    (prov:Invalidation)
+    (foaf:OnlineAccount)
+    (foaf:Organization)
+    (foaf:Person)
+    (org:Membership)
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a ?type .
+  }
+  GRAPH ?g {
+    ?s a ?type .
+    ?s ?p ?o .
+  }
+  FILTER (?g != <http://mu.semte.ch/graphs/public>)
+  FILTER EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?s ?p ?o .
+    }
+  }
+}

--- a/config/migrations/20221021094201-move-persons-to-public.sparql
+++ b/config/migrations/20221021094201-move-persons-to-public.sparql
@@ -16,14 +16,7 @@ WHERE {
   GRAPH ?g {
     ?s a person:Person .
     ?s ?p ?o .
-  }
-  FILTER (?g != <http://mu.semte.ch/graphs/public>)
-  FILTER EXISTS {
     [] mandaat:isBestuurlijkeAliasVan ?s .
   }
-  FILTER NOT EXISTS {
-    GRAPH <http://mu.semte.ch/graphs/public> {
-      ?s ?p ?o .
-    }
-  }
+  FILTER (?g != <http://mu.semte.ch/graphs/public>)
 }

--- a/config/migrations/20221021094201-move-persons-to-public.sparql
+++ b/config/migrations/20221021094201-move-persons-to-public.sparql
@@ -1,0 +1,29 @@
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a person:Person .
+    ?s ?p ?o .
+  }
+  FILTER (?g != <http://mu.semte.ch/graphs/public>)
+  FILTER EXISTS {
+    [] mandaat:isBestuurlijkeAliasVan ?s .
+  }
+  FILTER NOT EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?s ?p ?o .
+    }
+  }
+}

--- a/config/migrations/20221021094201-move-static-triples-to-public.sparql
+++ b/config/migrations/20221021094201-move-static-triples-to-public.sparql
@@ -1,0 +1,59 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX euvoc: <http://publications.europa.eu/ontology/euvoc#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+# Ignore incoming links. Either they come from another static type, which we will
+# move anyway, or they don't, then we want them to stay in the in their
+# respective graph.
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES (?type) {
+    (ext:DocumentTypeCode)
+    (ext:ThemaCode)
+    (ext:SysteemNotificatieType)
+    (ext:BeslissingsResultaatCode)
+    (ext:ProcedureStapType)
+    (pub:Publicatiestatus)
+    (pub:PublicatieWijze)
+    (pub:Urgentieniveau)
+    (pub:Publicatierapporttype)
+    (ext:RegelgevingType)
+    (euvoc:Language)
+    (org:Role)
+    (skos:Concept)
+    (skos:ConceptScheme)
+    (mandaat:Mandaat)
+    (mandaat:Mandataris)
+    (besluit:Bestuurseenheid)
+    (besluit:Bestuursorgaan)
+    (prov:Generation)
+    (prov:Invalidation)
+  }
+
+  GRAPH ?g {
+    ?s a ?type .
+    ?s ?p ?o .
+  }
+  FILTER (?g != <http://mu.semte.ch/graphs/public>)
+  FILTER NOT EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?s ?p ?o .
+    }
+  }
+}

--- a/config/migrations/20221021094201-move-static-triples-to-public.sparql
+++ b/config/migrations/20221021094201-move-static-triples-to-public.sparql
@@ -51,9 +51,4 @@ WHERE {
     ?s ?p ?o .
   }
   FILTER (?g != <http://mu.semte.ch/graphs/public>)
-  FILTER NOT EXISTS {
-    GRAPH <http://mu.semte.ch/graphs/public> {
-      ?s ?p ?o .
-    }
-  }
 }

--- a/config/migrations/20221021094206-remove-dossier-type-code.sparql
+++ b/config/migrations/20221021094206-remove-dossier-type-code.sparql
@@ -1,0 +1,15 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE WHERE {
+  GRAPH ?g {
+    ?o a ext:DossierTypeCode .
+    ?s ?p ?o .
+  }
+}
+;
+DELETE WHERE {
+  GRAPH ?g {
+    ?s a ext:DossierTypeCode .
+    ?s ?p ?o .
+  }
+}

--- a/config/migrations/20221021094214-remove-public-class.sparql
+++ b/config/migrations/20221021094214-remove-public-class.sparql
@@ -1,0 +1,7 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE WHERE {
+  GRAPH ?g {
+    ?type a ext:PublicClass .
+  }
+}


### PR DESCRIPTION
Updates `mu-authorization` config to remove unused types & adds migrations to move all public static types to the public graph, so we no longer duplicate them over all graphs.

Related PRs:
- [ ] https://github.com/kanselarij-vlaanderen/yggdrasil/pull/47