### PR TITLE
KAS-3663: Warm concepts in the cache

### DIFF
--- a/config/migrations/20221107124324-agendaitem-types-position.graph
+++ b/config/migrations/20221107124324-agendaitem-types-position.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20221107124324-agendaitem-types-position.ttl
+++ b/config/migrations/20221107124324-agendaitem-types-position.ttl
@@ -1,0 +1,2 @@
+<http://themis.vlaanderen.be/id/concept/agendapunt-type/dd47a8f8-3ad2-4d5a-8318-66fc02fe80fd> <http://schema.org/position> 1 .
+<http://themis.vlaanderen.be/id/concept/agendapunt-type/8f8adcf0-58ef-4edc-9e36-0c9095fd76b0> <http://schema.org/position> 2 .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     labels:
       - "logging=true"
   cache-warmup:
-    image: kanselarij/cache-warmup-service:1.6.0
+    image: kanselarij/cache-warmup-service:1.7.0
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
Adds `schema:position` to agendaitem type concepts so that we can sort them.