### PR TITLE
KAS-3658: Source file as main file

### DIFF
--- a/config/migrations/20221108104443-replace-ext-file-predicate-with-prov-value.sparql
+++ b/config/migrations/20221108104443-replace-ext-file-predicate-with-prov-value.sparql
@@ -1,0 +1,18 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+
+DELETE {
+  GRAPH ?g { ?piece ext:file ?file }
+}
+INSERT {
+  GRAPH ?g { ?piece prov:value ?file }
+}
+WHERE {
+  GRAPH ?g {
+		?piece a dossier:Stuk .
+		?file a nfo:FileDataObject .
+		?piece ext:file ?file .
+	}
+}

--- a/config/migrations/20221108104959-invert-source-and-derived-files.sparql
+++ b/config/migrations/20221108104959-invert-source-and-derived-files.sparql
@@ -1,0 +1,20 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+
+DELETE {
+  GRAPH ?g { ?piece prov:value ?derived }
+}
+INSERT {
+  GRAPH ?g { ?piece prov:value ?source }
+}
+WHERE {
+	GRAPH ?g {
+		?piece a dossier:Stuk .
+		?source a nfo:FileDataObject .
+		?derived a nfo:FileDataObject .
+		?derived prov:hadPrimarySource ?source .
+		?piece prov:value ?derived .
+	}
+}

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -25,10 +25,8 @@
                 (:access-level-last-modified          :datetime  ,(s-prefix "ext:accessLevelLastModified")))
   :has-one `((concept              :via ,(s-prefix "ext:toegangsniveauVoorDocumentVersie")
                                         :as "access-level")
-            (file                       :via      ,(s-prefix "ext:file")
+            (file                       :via      ,(s-prefix "prov:value")
                                         :as "file") ;; make this hasMany for publications
-            (file                       :via      ,(s-prefix "ext:convertedFile") ;; Deprecated. POC never taken in production. To be removed.
-                                        :as "converted-file")
             (document-container         :via      ,(s-prefix "dossier:collectie.bestaatUit")
                                         :inverse t
                                         :as "document-container")

--- a/config/resources/files-domain.lisp
+++ b/config/resources/files-domain.lisp
@@ -9,10 +9,10 @@
                                 :inverse t
                                 :as "download")
              (file              :via        ,(s-prefix "prov:hadPrimarySource")
-                                :as "primary-source")
+                                :as "source")
              (file              :via        ,(s-prefix "prov:hadPrimarySource")
                                 :inverse t
-                                :as "primary-source-of"))
+                                :as "derived"))
   :resource-base (s-url "http://themis.vlaanderen.be/id/bestand/")
   :features `(no-pagination-defaults include-uri)
   :on-path "files")

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -127,7 +127,7 @@
         "data": {
           "via": [
             "http://data.vlaanderen.be/ns/besluitvorming#geagendeerdStuk",
-            "http://mu.semte.ch/vocabularies/ext/file",
+            "http://www.w3.org/ns/prov#value",
             "^http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource"
           ],
           "attachment_pipeline": "attachment"
@@ -258,7 +258,7 @@
           "via": [
             "^https://data.vlaanderen.be/ns/dossier#Dossier.isNeerslagVan",
             "https://data.vlaanderen.be/ns/dossier#Dossier.bestaatUit",
-            "http://mu.semte.ch/vocabularies/ext/file",
+            "http://www.w3.org/ns/prov#value",
             "^http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource"
           ],
           "attachment_pipeline": "attachment"
@@ -268,7 +268,7 @@
             "https://data.vlaanderen.be/ns/dossier#doorloopt",
             "^http://mu.semte.ch/vocabularies/ext/beslissingVindtPlaatsTijdens",
             "^http://data.vlaanderen.be/ns/besluitvorming#beschrijft",
-            "http://mu.semte.ch/vocabularies/ext/file",
+            "http://www.w3.org/ns/prov#value",
             "^http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource"
           ],
           "attachment_pipeline": "attachment"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,7 +202,7 @@ services:
     labels:
       - "logging=true"
   file-bundling-job-creation:
-    image: kanselarij/file-bundling-job-creation-service:0.1.6
+    image: kanselarij/file-bundling-job-creation-service:0.2.0
     logging: *default-logging
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,7 +182,7 @@ services:
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:feature-KAS-3658-source-file-as-main-file
+    image: kanselarij/yggdrasil:5.12.0
     logging: *default-logging
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,7 +182,7 @@ services:
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:5.11.0
+    image: kanselarij/yggdrasil:feature-KAS-3658-source-file-as-main-file
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
- Make existing source files be the "main" file of a piece
- Replace the predicate between piece and file
  - Update Elastic config to find files
- Rename relations between file and derived (now `source` and `derived` instead of `primarySource` and `primarySourceOf`
- `testdata.zip` contains Piece with a file that has a derived file. First uploaded using the old version (so file + source file), then after migrations ran it was correctly set as source file + derived file. (This was my best attempt at showcasing the the main migration of this story actually works and is kind-of testable)