### PR TITLE
Static file service to host frontend

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -19,6 +19,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://frontend/assets/"
   end
 
+  get "/@appuniversum/*path", @frontend do
+    Proxy.forward conn, path, "http://frontend/@appuniversum/"
+  end
+
   get "/torii/redirect.html", @frontend do
     Proxy.forward conn, [], "http://frontend/torii/redirect.html"
   end


### PR DESCRIPTION
Since frontend is now hosted behind the dispatcher using a static file service all redirection logic (eg. torii callback, appuniversum assets) previously executed by the frontend needs to be done now by the dispatcher. 

See also https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1535