### PR TITLE
KAS-3678: Disable old print routes

### DIFF
--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -38,10 +38,10 @@
                 ;; (:retracted           :boolean  ,(s-prefix "besluitvorming:ingetrokken")) ;; still exists in legacy until we sort inconsistensies in data
                 (:number              :integer  ,(s-prefix "schema:position"))
                 (:for-press           :boolean  ,(s-prefix "ext:forPress"))
-                (:title-press         :string   ,(s-prefix "besluitvorming:titelPersagenda"))  ;; NOTE: What is the URI of property 'titelPersagenda'? Made up besluitvorming:titelPersagenda
+                ;; (:title-press         :string   ,(s-prefix "besluitvorming:titelPersagenda")) NOTE: this property is unused, but data is still available in the database
                 (:comment             :string   ,(s-prefix "schema:comment"))
                 (:private-comment     :string   ,(s-prefix "ext:privateComment"))
-                (:text-press          :string   ,(s-prefix "besluitvorming:tekstPersagenda"))
+                ;; (:text-press          :string   ,(s-prefix "besluitvorming:tekstPersagenda")) NOTE: this property is unused, but data is still available in the database
                 ;; Added properties from subcases
                 (:short-title         :string   ,(s-prefix "besluitvorming:korteTitel"))
                 (:title               :string   ,(s-prefix "dct:title"))

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -76,8 +76,6 @@
       "properties": {
         "title": "http://purl.org/dc/terms/title",
         "shortTitle": "http://data.vlaanderen.be/ns/besluitvorming#korteTitel",
-        "titlePress": "http://data.vlaanderen.be/ns/besluitvorming#titelPersagenda",
-        "textPress": "http://data.vlaanderen.be/ns/besluitvorming#tekstPersagenda",
         "agendaId": [
           "^http://purl.org/dc/terms/hasPart",
           "http://mu.semte.ch/vocabularies/core/uuid"
@@ -141,16 +139,6 @@
             "search_analyzer": "dutchanalyzer"
           },
           "shortTitle": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer"
-          },
-          "titlePress": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer"
-          },
-          "textPress": {
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"


### PR DESCRIPTION
Removes unused properties from the resource config (but they're still in comment with a note about the data still being there)