### PR TITLE
KAS-3664: Predicate migrations

### DIFF
--- a/config/migrations/20221118103802-vertrouwelijkheidsniveau-predicaat.sparql
+++ b/config/migrations/20221118103802-vertrouwelijkheidsniveau-predicaat.sparql
@@ -1,5 +1,5 @@
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
 DELETE {
   GRAPH ?g { ?thing ext:toegangsniveauVoorDocumentVersie ?accessLevel . }
 }

--- a/config/migrations/20221118103802-vertrouwelijkheidsniveau-predicaat.sparql
+++ b/config/migrations/20221118103802-vertrouwelijkheidsniveau-predicaat.sparql
@@ -1,0 +1,11 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+DELETE {
+  GRAPH ?g { ?thing ext:toegangsniveauVoorDocumentVersie ?accessLevel . }
+}
+INSERT {
+  GRAPH ?g { ?thing besluitvorming:vertrouwelijkheidsniveau ?accessLevel . }
+}
+WHERE {
+  GRAPH ?g { ?thing ext:toegangsniveauVoorDocumentVersie ?accessLevel . }
+}

--- a/config/migrations/20221118124351-collectie-bestaat-uit-predicate.sparql
+++ b/config/migrations/20221118124351-collectie-bestaat-uit-predicate.sparql
@@ -1,0 +1,11 @@
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+
+DELETE {
+  GRAPH ?g { ?thing dossier:collectie.bestaatUit ?docContainer . }
+}
+INSERT {
+  GRAPH ?g { ?thing dossier:Collectie.bestaatUit ?docContainer . }
+}
+WHERE {
+  GRAPH ?g { ?thing dossier:collectie.bestaatUit ?docContainer . }
+}

--- a/config/migrations/20221118130306-agendaitem-heeft-onderwerp-predicaat.sparql
+++ b/config/migrations/20221118130306-agendaitem-heeft-onderwerp-predicaat.sparql
@@ -1,0 +1,11 @@
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX dct: <http://purl.org/dc/terms/>
+DELETE {
+  GRAPH ?g { ?thing besluitvorming:heeftOnderwerp ?agendaItemTreatment }
+}
+INSERT {
+  GRAPH ?g { ?thing dct:subject ?agendaItemTreatment }
+}
+WHERE {
+  GRAPH ?g { ?thing besluitvorming:heeftOnderwerp ?agendaItemTreatment }
+}

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -63,7 +63,7 @@
              (agenda-activity         :via      ,(s-prefix "besluitvorming:genereertAgendapunt")
                                       :inverse t
                                       :as "agenda-activity")
-             (agenda-item-treatment   :via        ,(s-prefix "besluitvorming:heeftOnderwerp")
+             (agenda-item-treatment   :via        ,(s-prefix "dct:subject")
                                       :inverse t
                                       :as "treatment")
              (concept                 :via ,(s-prefix "dct:type")
@@ -94,7 +94,7 @@
   :has-many `(
              ;; agenda-item-treatment has multiple agenda-items in the sense that there is one
              ;; agenda-item version per version of the agenda
-             (agendaitem            :via        ,(s-prefix "besluitvorming:heeftOnderwerp")
+             (agendaitem            :via        ,(s-prefix "dct:subject")
                                     :as "agendaitems"))
   :resource-base (s-url "http://themis.vlaanderen.be/id/behandeling-van-agendapunt/")
   :features '(include-uri)

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -1,7 +1,7 @@
 (define-resource document-container ()
   :class (s-prefix "dossier:Serie")
   :properties `((:created               :datetime ,(s-prefix "dct:created")))
-  :has-many `((piece                    :via ,(s-prefix "dossier:collectie.bestaatUit") ;; TODO should become `dossier:Collectie.bestaatUit`
+  :has-many `((piece                    :via ,(s-prefix "dossier:Collectie.bestaatUit")
                                         :as "pieces"))
   :has-one `((concept                   :via ,(s-prefix "dct:type")
                                         :as "type")
@@ -29,7 +29,7 @@
                                         :as "file") ;; make this hasMany for publications
             (file                       :via      ,(s-prefix "ext:convertedFile") ;; Deprecated. POC never taken in production. To be removed.
                                         :as "converted-file")
-            (document-container         :via      ,(s-prefix "dossier:collectie.bestaatUit")
+            (document-container         :via      ,(s-prefix "dossier:Collectie.bestaatUit")
                                         :inverse t
                                         :as "document-container")
             (piece                      :via      ,(s-prefix "pav:previousVersion")

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -23,7 +23,7 @@
                 (:number-of-pages       :integer   ,(s-prefix "fabio:hasPageCount"))
                 (:number-of-words       :integer   ,(s-prefix "prism:wordCount"))
                 (:access-level-last-modified          :datetime  ,(s-prefix "ext:accessLevelLastModified")))
-  :has-one `((concept              :via ,(s-prefix "ext:toegangsniveauVoorDocumentVersie")
+  :has-one `((concept              :via ,(s-prefix "besluitvorming:vertrouwelijkheidsniveau")
                                         :as "access-level")
             (file                       :via      ,(s-prefix "ext:file")
                                         :as "file") ;; make this hasMany for publications

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -520,7 +520,7 @@
         "agendaitems": {
           "via": [
             "^http://www.w3.org/ns/prov#generated",
-            "http://data.vlaanderen.be/ns/besluitvorming#heeftOnderwerp"
+            "http://purl.org/dc/terms/subject"
           ],
           "rdf_type": "http://data.vlaanderen.be/ns/besluit#Agendapunt",
           "properties" : {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
     labels:
       - "logging=true"
   agenda-approve:
-    image: kanselarij/agenda-approve-service:5.5.0
+    image: kanselarij/agenda-approve-service:5.6.0
     logging: *default-logging
     restart: always
     labels:
@@ -176,13 +176,13 @@ services:
     labels:
       - "logging=true"
   newsletter:
-    image: kanselarij/newsletter-service:3.4.0
+    image: kanselarij/newsletter-service:3.5.0
     logging: *default-logging
     restart: always
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:5.10.0
+    image: kanselarij/yggdrasil:5.11.0
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
Replaces three predicates:
- `ext:toegangsniveauVoorDocumentVersie` → `besluitvorming:vertrouwelijkheidsniveau`
- `besluitvorming:heeftOnderwerp` → `dct:subject`
- `dossier:collectie.bestaatUit` → `dossier:Collectie.bestaatUit`

Related PRs:
- [x] https://github.com/kanselarij-vlaanderen/newsletter-service/pull/48
- [x] https://github.com/kanselarij-vlaanderen/agenda-approve-service/pull/31
- [x] https://github.com/kanselarij-vlaanderen/yggdrasil/pull/50
- [x] https://github.com/kanselarij-vlaanderen/public-file-service/pull/3
- [x] https://github.com/kanselarij-vlaanderen/themis-export-service/pull/12
- [x] https://github.com/kanselarij-vlaanderen/legacy-data-service/pull/1