### PR TITLE
Role hotfixes for PROD

### DIFF
--- a/config/migrations/20221129101115-add-both-notations-for-cabinet-roles.sparql
+++ b/config/migrations/20221129101115-add-both-notations-for-cabinet-roles.sparql
@@ -1,0 +1,17 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://themis.vlaanderen.be/id/gebruikersrol/6bcebe59-0cb5-4c5e-ab40-ca98b65887a4> skos:notation "Kaleidos_Kabinetdossierbeheerder" .
+    <http://themis.vlaanderen.be/id/gebruikersrol/6bcebe59-0cb5-4c5e-ab40-ca98b65887a4> skos:notation "Kaleidos_Kabinetsdossierbeheerder" .
+  }
+}
+
+;
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://themis.vlaanderen.be/id/gebruikersrol/33dbca4a-7e57-41d2-a26c-aedef422ff84> skos:notation "Kaleidos_Kabinetmedewerker" .
+    <http://themis.vlaanderen.be/id/gebruikersrol/33dbca4a-7e57-41d2-a26c-aedef422ff84> skos:notation "Kaleidos_Kabinetsmedewerker" .
+  }
+}

--- a/config/migrations/20221129140337-remove-oc-raadgever-role.sparql
+++ b/config/migrations/20221129140337-remove-oc-raadgever-role.sparql
@@ -1,0 +1,7 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE WHERE {
+  <http://themis.vlaanderen.be/id/gebruikersrol/a12965ec-e95a-4f7b-8911-7bbb41ce29d9> ?p ?o .
+  ?membership org:role <http://themis.vlaanderen.be/id/gebruikersrol/a12965ec-e95a-4f7b-8911-7bbb41ce29d9> .
+  ?membership ?mp ?mo .
+}

--- a/config/migrations/20221129141454-remove-oc-raadgever-mock-user.sparql
+++ b/config/migrations/20221129141454-remove-oc-raadgever-mock-user.sparql
@@ -1,0 +1,7 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+DELETE WHERE {
+  <http://themis.vlaanderen.be/id/gebruiker/1a6c420c-e209-46fb-a2cb-cd3aeceec765> ?p ?o .
+  ?account foaf:account <http://themis.vlaanderen.be/id/gebruiker/1a6c420c-e209-46fb-a2cb-cd3aeceec765> .
+  ?account ?ap ?ao .
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,7 @@ services:
     image: kanselarij/mock-login-service:2.2.0
     logging: *default-logging
   login:
-    image: kanselarij/acmidm-login-service:2.2.0
+    image: kanselarij/acmidm-login-service:2.3.0
     environment:
       MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
       MU_APPLICATION_AUTH_CLIENT_ID: "b1c78c1e-3c88-44f4-90fa-bebc5c5dc28d"


### PR DESCRIPTION
Some hotfixes for PROD regarding ACM/IDM roles.

- Add `skos:notation` for the Cabinet roles with and without `s` → Kabinet**s**medewerker & Kabinet**s**dossierbeheerder
- Remove OC raadgever role (see: https://github.com/search?q=org%3Akanselarij-vlaanderen+a12965ec-e95a-4f7b-8911-7bbb41ce29d9&type=code, seemingly only usage was in frontend constant definition)
- Login service accepts all organization identifiers, not only OVO codes

:warning: Bump ACM/IDM Login service before merging!