### PR TITLE
warmup cache for cypress tests

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -59,7 +59,10 @@ services:
   cache-warmup:
     restart: "no"
     environment:
-      AUTO_RUN: "false"
+      AUTO_RUN: "true"
+      ENABLE_RECENT_AGENDAS_CACHE: "false"
+      ENABLE_LARGE_AGENDAS_CACHE: "false"
+      ENABLE_CONCEPTS_CACHE: "true"
   cache:
     restart: "no"
   resource:


### PR DESCRIPTION
I think the cache-warmup is not running on jenkins because government field tests are still failing.
Adding the env properties to CI docker-compose override