### PR TITLE
KAS-3724 cleanup unused relation besluitvorming:genereertVerslag

### DIFF
--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -4,11 +4,7 @@
   :has-many `((piece                    :via ,(s-prefix "dossier:Collectie.bestaatUit")
                                         :as "pieces"))
   :has-one `((concept                   :via ,(s-prefix "dct:type")
-                                        :as "type")
-             (agenda-item-treatment     :via ,(s-prefix "besluitvorming:genereertVerslag")
-                                        :inverse t
-                                        :as "agenda-item-treatment")
-                                        )
+                                        :as "type"))
   :resource-base (s-url "http://themis.vlaanderen.be/id/serie/")
   :features '(include-uri)
   :on-path "document-containers")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,7 +182,7 @@ services:
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:5.12.0
+    image: kanselarij/yggdrasil:5.12.1
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3724

see also yggdrasil:
https://github.com/kanselarij-vlaanderen/yggdrasil/pull/52

Verified again on ACC and PROD.
No triples are found with this predicate.

checked with
```
PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>

SELECT count(*) WHERE {
  GRAPH ?g {
      ?anything besluitvorming:genereertVerslag ?anything.
  }
}

```

Also checked with `https` for good measure. 