### PR TITLE
Feature/kas 3731 file service cleanup

### DIFF
--- a/config/migrations/20221215203103-delete-orphaned-document-containers.sparql
+++ b/config/migrations/20221215203103-delete-orphaned-document-containers.sparql
@@ -1,0 +1,15 @@
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+
+DELETE WHERE {
+  GRAPH ?g {
+    ?documentContainer a dossier:Serie .
+    FILTER NOT EXISTS { ?documentContainer dossier:Collectie.bestaatUit ?piece }
+  }
+}
+;
+DELETE WHERE {
+  GRAPH ?g {
+    ?documentContainer a dossier:Serie .
+    FILTER NOT EXISTS { ?documentContainer dossier:Collectie.bestaatUit ?piece }
+  }
+}

--- a/config/migrations/20221215203103-delete-orphaned-document-containers.sparql
+++ b/config/migrations/20221215203103-delete-orphaned-document-containers.sparql
@@ -1,15 +1,12 @@
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 
-DELETE WHERE {
-  GRAPH ?g {
-    ?documentContainer a dossier:Serie .
-    FILTER NOT EXISTS { ?documentContainer dossier:Collectie.bestaatUit ?piece }
-  }
+DELETE {
+  GRAPH ?g { ?documentContainer ?p ?o . }
 }
-;
-DELETE WHERE {
+WHERE {
   GRAPH ?g {
     ?documentContainer a dossier:Serie .
+    ?documentContainer ?p ?o .
     FILTER NOT EXISTS { ?documentContainer dossier:Collectie.bestaatUit ?piece }
   }
 }


### PR DESCRIPTION
Removes orphaned document containers, i.e. document containers with no attached pieces.

This migration is pretty weird. It executes the same delete twice because for some unknown reason, doing it only once leaves some document containers in the DB. On a recent-ish ACC database there are 271 orphaned document containers. After running the migration once, there remained 113 orphaned document containers. After runnning it again, there were no orphaned containers left.