### PR TITLE
fix: make Nieuwsbericht migrations only apply to Kanselarij graph

### DIFF
--- a/config/migrations/20221213180153-nieuwsbericht-predicate-subtitle.sparql
+++ b/config/migrations/20221213180153-nieuwsbericht-predicate-subtitle.sparql
@@ -2,15 +2,14 @@ PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX dbpedia: <http://dbpedia.org/ontology/>
 PREFIX dct: <http://purl.org/dc/terms/>
 
+WITH <http://mu.semte.ch/graphs/organizations/kanselarij>
 DELETE {
-  GRAPH ?g { ?newsItem dbpedia:subtitle ?subtitle . }
+  ?newsItem dbpedia:subtitle ?subtitle .
 }
 INSERT {
-  GRAPH ?g { ?newsItem dct:alternative ?subtitle . }
+  ?newsItem dct:alternative ?subtitle .
 }
 WHERE {
-  GRAPH ?g {
-    ?newsItem a besluitvorming:NieuwsbriefInfo .
-    ?newsItem dbpedia:subtitle ?subtitle .
-  }
+  ?newsItem a besluitvorming:NieuwsbriefInfo .
+  ?newsItem dbpedia:subtitle ?subtitle .
 }

--- a/config/migrations/20221213180219-nieuwsbericht-predicate-html-content.sparql
+++ b/config/migrations/20221213180219-nieuwsbericht-predicate-html-content.sparql
@@ -2,15 +2,14 @@ PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
+WITH <http://mu.semte.ch/graphs/organizations/kanselarij>
 DELETE {
-  GRAPH ?g { ?newsItem ext:htmlInhoud ?htmlContent . }
+  ?newsItem ext:htmlInhoud ?htmlContent .
 }
 INSERT {
-  GRAPH ?g { ?newsItem nie:htmlContent ?htmlContent . }
+  ?newsItem nie:htmlContent ?htmlContent .
 }
 WHERE {
-  GRAPH ?g {
-    ?newsItem a besluitvorming:NieuwsbriefInfo .
-    ?newsItem ext:htmlInhoud ?htmlContent .
-  }
+  ?newsItem a besluitvorming:NieuwsbriefInfo .
+  ?newsItem ext:htmlInhoud ?htmlContent .
 }

--- a/config/migrations/20221213180226-nieuwsbericht-predicate-plain-text.sparql
+++ b/config/migrations/20221213180226-nieuwsbericht-predicate-plain-text.sparql
@@ -2,15 +2,14 @@ PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 
+WITH <http://mu.semte.ch/graphs/organizations/kanselarij>
 DELETE {
-  GRAPH ?g { ?newsItem besluitvorming:inhoud ?plainText . }
+  ?newsItem besluitvorming:inhoud ?plainText .
 }
 INSERT {
-  GRAPH ?g { ?newsItem prov:value ?plainText . }
+  ?newsItem prov:value ?plainText .
 }
 WHERE {
-  GRAPH ?g {
-    ?newsItem a besluitvorming:NieuwsbriefInfo .
-    ?newsItem besluitvorming:inhoud ?plainText .
-  }
+  ?newsItem a besluitvorming:NieuwsbriefInfo .
+  ?newsItem besluitvorming:inhoud ?plainText .
 }

--- a/config/migrations/20221213180236-nieuwsbericht-predicate-remark.sparql
+++ b/config/migrations/20221213180236-nieuwsbericht-predicate-remark.sparql
@@ -2,15 +2,14 @@ PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
+WITH <http://mu.semte.ch/graphs/organizations/kanselarij>
 DELETE {
-  GRAPH ?g { ?newsItem ext:opmerking ?remark . }
+  ?newsItem ext:opmerking ?remark .
 }
 INSERT {
-  GRAPH ?g { ?newsItem rdfs:comment ?remark . }
+  ?newsItem rdfs:comment ?remark .
 }
 WHERE {
-  GRAPH ?g {
-    ?newsItem a besluitvorming:NieuwsbriefInfo .
-    ?newsItem ext:opmerking ?remark .
-  }
+  ?newsItem a besluitvorming:NieuwsbriefInfo .
+  ?newsItem ext:opmerking ?remark .
 }

--- a/config/migrations/20221213180243-nieuwsbericht-predicate-modified.sparql
+++ b/config/migrations/20221213180243-nieuwsbericht-predicate-modified.sparql
@@ -2,15 +2,14 @@ PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
+WITH <http://mu.semte.ch/graphs/organizations/kanselarij>
 DELETE {
-  GRAPH ?g { ?newsItem ext:aangepastOp ?modified . }
+  ?newsItem ext:aangepastOp ?modified .
 }
 INSERT {
-  GRAPH ?g { ?newsItem dct:modified ?modified . }
+  ?newsItem dct:modified ?modified .
 }
 WHERE {
-  GRAPH ?g {
-    ?newsItem a besluitvorming:NieuwsbriefInfo .
-    ?newsItem ext:aangepastOp ?modified .
-  }
+  ?newsItem a besluitvorming:NieuwsbriefInfo .
+  ?newsItem ext:aangepastOp ?modified .
 }

--- a/config/migrations/20221213180251-nieuwsbericht-predicate-agenda-item-treatment.sparql
+++ b/config/migrations/20221213180251-nieuwsbericht-predicate-agenda-item-treatment.sparql
@@ -2,15 +2,14 @@ PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 
+WITH <http://mu.semte.ch/graphs/organizations/kanselarij>
 DELETE {
-  GRAPH ?g { ?agendaItemTreatment prov:generated ?newsItem . }
+  ?agendaItemTreatment prov:generated ?newsItem .
 }
 INSERT {
-  GRAPH ?g { ?newsItem prov:wasDerivedFrom ?agendaItemTreatment . }
+  ?newsItem prov:wasDerivedFrom ?agendaItemTreatment .
 }
 WHERE {
-  GRAPH ?g {
-    ?newsItem a besluitvorming:NieuwsbriefInfo .
-    ?agendaItemTreatment prov:generated ?newsItem .
-  }
+  ?newsItem a besluitvorming:NieuwsbriefInfo .
+  ?agendaItemTreatment prov:generated ?newsItem .
 }

--- a/config/migrations/20221213180301-nieuwsbericht-predicate-attachments.sparql
+++ b/config/migrations/20221213180301-nieuwsbericht-predicate-attachments.sparql
@@ -1,15 +1,14 @@
 PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
+WITH <http://mu.semte.ch/graphs/organizations/kanselarij>
 DELETE {
-  GRAPH ?g { ?newsItem ext:documentenVoorPublicatie ?attachments . }
+  ?newsItem ext:documentenVoorPublicatie ?attachments .
 }
 INSERT {
-  GRAPH ?g { ?newsItem besluitvorming:heeftBijlage ?attachments . }
+  ?newsItem besluitvorming:heeftBijlage ?attachments .
 }
 WHERE {
-  GRAPH ?g {
-    ?newsItem a besluitvorming:NieuwsbriefInfo .
-    ?newsItem ext:documentenVoorPublicatie ?attachments .
-  }
+  ?newsItem a besluitvorming:NieuwsbriefInfo .
+  ?newsItem ext:documentenVoorPublicatie ?attachments .
 }

--- a/config/migrations/20221213180412-nieuwsbericht-predicate-type.sparql
+++ b/config/migrations/20221213180412-nieuwsbericht-predicate-type.sparql
@@ -2,12 +2,13 @@ PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
+WITH <http://mu.semte.ch/graphs/organizations/kanselarij>
 DELETE {
-  GRAPH ?g { ?newsItem a besluitvorming:NieuwsbriefInfo . }
+  ?newsItem a besluitvorming:NieuwsbriefInfo .
 }
 INSERT {
-  GRAPH ?g { ?newsItem a ext:Nieuwsbericht . }
+  ?newsItem a ext:Nieuwsbericht .
 }
 WHERE {
-  GRAPH ?g { ?newsItem a besluitvorming:NieuwsbriefInfo . }
+  ?newsItem a besluitvorming:NieuwsbriefInfo .
 }

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -34,7 +34,7 @@
             (subcase                    :via ,(s-prefix "ext:bevatReedsBezorgdeDocumentversie") ;; should be hasMany, not used in frontend yet
                                         :inverse t
                                         :as "linked-subcase")
-            (news-item                  :via ,(s-prefix "ext:documentenVoorPublicatie")
+            (news-item                  :via ,(s-prefix "besluitvorming:heeftBijlage")
                                         :inverse t
                                         :as "news-item")
             (meeting                    :via ,(s-prefix "ext:zittingDocumentversie")


### PR DESCRIPTION
This means we need to repropagate data via Yggdrasil