### PR TITLE
KAS-3791: Agendaitem search tuning

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -107,11 +107,6 @@
           "http://mu.semte.ch/vocabularies/ext/heeftBevoegdeVoorAgendapunt",
           "http://purl.org/dc/terms/title"
         ],
-        "mandateeName": [
-          "http://mu.semte.ch/vocabularies/ext/heeftBevoegdeVoorAgendapunt",
-          "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
-          "http://xmlns.com/foaf/0.1/name"
-        ],
         "mandateeFirstNames": [
           "http://mu.semte.ch/vocabularies/ext/heeftBevoegdeVoorAgendapunt",
           "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
@@ -207,11 +202,6 @@
             "type": "date"
           },
           "mandateRoles": {
-            "type": "text",
-            "analyzer": "dutchanalyzer",
-            "search_analyzer": "dutchanalyzer"
-          },
-          "mandateeName": {
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -103,6 +103,10 @@
           "http://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
           "http://data.vlaanderen.be/ns/besluit#geplandeStart"
         ],
+        "mandateRoles": [
+          "http://mu.semte.ch/vocabularies/ext/heeftBevoegdeVoorAgendapunt",
+          "http://purl.org/dc/terms/title"
+        ],
         "mandateeName": [
           "http://mu.semte.ch/vocabularies/ext/heeftBevoegdeVoorAgendapunt",
           "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
@@ -122,14 +126,52 @@
           "http://data.vlaanderen.be/ns/besluitvorming#geagendeerdStuk",
           "http://purl.org/dc/terms/title"
         ],
-        "data": {
+        "pieceFileNames": [
+          "http://data.vlaanderen.be/ns/besluitvorming#geagendeerdStuk",
+          "http://www.w3.org/ns/prov#value",
+          "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName"
+        ],
+        "pieces": {
           "via": [
             "http://data.vlaanderen.be/ns/besluitvorming#geagendeerdStuk",
             "http://www.w3.org/ns/prov#value",
             "^http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource"
           ],
           "attachment_pipeline": "attachment"
-        }
+        },
+        "decisionName": [
+          "^http://purl.org/dc/terms/subject",
+          "http://data.vlaanderen.be/ns/besluitvorming#heeftBeslissing",
+          "^http://data.vlaanderen.be/ns/besluitvorming#beschrijft",
+          "http://purl.org/dc/terms/title"
+        ],
+        "decisionFileName": [
+          "^http://purl.org/dc/terms/subject",
+          "http://data.vlaanderen.be/ns/besluitvorming#heeftBeslissing",
+          "^http://data.vlaanderen.be/ns/besluitvorming#beschrijft",
+          "http://www.w3.org/ns/prov#value",
+          "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName"
+        ],
+        "decision": {
+          "via": [
+            "^http://purl.org/dc/terms/subject",
+            "http://data.vlaanderen.be/ns/besluitvorming#heeftBeslissing",
+            "^http://data.vlaanderen.be/ns/besluitvorming#beschrijft",
+            "http://www.w3.org/ns/prov#value",
+            "^http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource"
+          ],
+          "attachment_pipeline": "attachment"
+        },
+        "newsItemTitle": [
+          "^http://purl.org/dc/terms/subject",
+          "^http://www.w3.org/ns/prov#wasDerivedFrom",
+          "http://purl.org/dc/terms/title"
+        ],
+        "newsItem": [
+          "^http://purl.org/dc/terms/subject",
+          "^http://www.w3.org/ns/prov#wasDerivedFrom",
+          "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#htmlContent"
+        ]
       },
       "mappings": {
         "properties": {
@@ -164,6 +206,11 @@
           "sessionDates": {
             "type": "date"
           },
+          "mandateRoles": {
+            "type": "text",
+            "analyzer": "dutchanalyzer",
+            "search_analyzer": "dutchanalyzer"
+          },
           "mandateeName": {
             "type": "text",
             "analyzer": "dutchanalyzer",
@@ -184,11 +231,42 @@
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"
           },
-          "data.content": {
+          "pieceFileNames": {
+            "type": "text",
+            "analyzer": "dutchanalyzer",
+            "search_analyzer": "dutchanalyzer"
+          },
+          "pieces.content": {
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer",
             "term_vector": "with_positions_offsets_payloads"
+          },
+          "decisionName": {
+            "type": "text",
+            "analyzer": "dutchanalyzer",
+            "search_analyzer": "dutchanalyzer"
+          },
+          "decisionFileName": {
+            "type": "text",
+            "analyzer": "dutchanalyzer",
+            "search_analyzer": "dutchanalyzer"
+          },
+          "decision.content": {
+            "type": "text",
+            "analyzer": "dutchanalyzer",
+            "search_analyzer": "dutchanalyzer",
+            "term_vector": "with_positions_offsets_payloads"
+          },
+          "newsItemTitle": {
+            "type": "text",
+            "analyzer": "dutchanalyzer",
+            "search_analyzer": "dutchanalyzer"
+          },
+          "newsItem": {
+            "type": "text",
+            "analyzer": "dutchanalyzer",
+            "search_analyzer": "dutchanalyzer"
           }
         }
       }


### PR DESCRIPTION
Adds the following fields to the agendaitem search index:

- mandateRoles: "Vlaams minister van Welzijn, Volksgezondheid en Gezin", "Vlaams minister van Binnenlands Bestuur, Bestuurszaken, Inburgering en Gelijke Kansen", etc.
- pieceFileNames: filename of the actual files uploaded by users as pieces attached to the agendaitem
- decisionName: title of the piece that is attached to a `decision-activity`
- decisionFileName: filename of the actual file uploaded by user attached to the decision
- decision: the content of the decision's file
- newsItemTitle: the title of the news-item (kort bestek)
- newsItem: the HTML content of the news-item

`data` was renamed to `pieces` (which contains the actual file contents of the pieces), since we're now storing multiple kinds of files

`mandateeName` was removed because we don't actually store a `foaf:name` value for people.