### PR TITLE
KAS-3793: add mandatee ids to news items search index

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -538,6 +538,10 @@
               "rdf_type": "http://data.vlaanderen.be/ns/mandaat#Mandataris",
               "properties" : {
                 "priority": "http://data.vlaanderen.be/ns/mandaat#rangorde",
+                "id": [
+                  "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
+                  "http://mu.semte.ch/vocabularies/core/uuid"
+                ],
                 "firstName": [
                   "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
                   "https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam"
@@ -594,6 +598,9 @@
           },
           "agendaitems.mandatees.priority": {
             "type": "short"
+          },
+          "agendaitems.mandatees.id": {
+            "type": "keyword"
           },
           "agendaitems.mandatees.firstName": {
             "type": "text",


### PR DESCRIPTION
Adds the mandatee's person's ID to the news-item search index so we can use it for filtering in the frontend.