### PR TITLE
KAS-3814: Merge app themis export

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,17 @@ Most of Kaleidos' data is structured according the vocabularies & application-pr
 - [Dossier](https://data.vlaanderen.be/doc/applicatieprofiel/dossier/)
 - [Mandatendatabank](https://data.vlaanderen.be/doc/applicatieprofiel/mandatendatabank/)
 
-Part of the data produced within Kaleidos will soon be published as open-data through the "Themis"-portal. Please consult https://themis.vlaanderen.be/ for more information.
+### Open-data publication to Themis
+
+Part of the data produced within Kaleidos is published as open-data through the "Themis"-portal. Please consult https://themis.vlaanderen.be/ for more information.
+
+The sync to Themis works with a pull-mechanism. Kaleidos generates and provides publications, which are polled and fetched at regular intervals by the Themis stack.
+
+The services used to generate data exports for Themis:
+- an [export service](https://github.com/kanselarij-vlaanderen/themis-export-service) responsible for collecting data from Kaleidos and generating a TTL data dump
+- a [TTL to delta conversion service](https://github.com/redpencilio/ttl-to-delta-service) to convert the TTL data dump to the delta format
+- a [producer service](https://github.com/kanselarij-vlaanderen/themis-publication-producer) providing an endpoint to fetch publications for interested consumers
+- a [public file service](https://github.com/kanselarij-vlaanderen/public-file-service) providing an endpoint for interested consumers to fetch public Kaleidos documents
+
+The main component of the [Themis stack](https://github.com/kanselarij-vlaanderen/app-themis) is the [Themis publication consumer service](https://github.com/kanselarij-vlaanderen/themis-publication-consumer) responsible for polling and fetching of the publications and accompanying documents.
 

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -276,7 +276,8 @@ defmodule Acl.UserGroups.Config do
               resource_types: public_static_data() ++
               public_codelists() ++
               system_resource_types() ++
-              user_account_resource_types() # required to list mock accounts for unauthenticated users
+              user_account_resource_types() ++ # required to list mock accounts for unauthenticated users
+              themis_export_types()
             } },
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/sessions",
@@ -443,18 +444,6 @@ defmodule Acl.UserGroups.Config do
         ]
       },
 
-      # Read-write access to public graph for Themis export types
-      %GroupSpec{
-        name: "themis-export",
-        useage: [:read, :write, :read_for_write],
-        access: %AlwaysAccessible{},
-        graphs: [
-          %GraphSpec{
-            graph: "http://mu.semte.ch/graphs/public",
-            constraint: %ResourceConstraint{
-              resource_types: themis_export_types()
-            } } ]
-      },
       # // CLEANUP
       #
       %GraphCleanup{

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -276,8 +276,7 @@ defmodule Acl.UserGroups.Config do
               resource_types: public_static_data() ++
               public_codelists() ++
               system_resource_types() ++
-              user_account_resource_types() ++ # required to list mock accounts for unauthenticated users
-              themis_export_types()
+              user_account_resource_types() # required to list mock accounts for unauthenticated users
             } },
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/sessions",
@@ -444,6 +443,18 @@ defmodule Acl.UserGroups.Config do
         ]
       },
 
+      # Read-write access to public graph for Themis export types
+      %GroupSpec{
+        name: "themis-export",
+        useage: [:read, :write, :read_for_write],
+        access: %AlwaysAccessible{},
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/public",
+            constraint: %ResourceConstraint{
+              resource_types: themis_export_types()
+            } } ]
+      },
       # // CLEANUP
       #
       %GraphCleanup{

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -214,6 +214,13 @@ defmodule Acl.UserGroups.Config do
     ]
   end
 
+  defp themis_export_types() do
+    [
+      "http://mu.semte.ch/vocabularies/ext/PublicExportJob",
+      "http://mu.semte.ch/vocabularies/ext/TtlToDeltaTask"
+    ]
+  end
+
   defp system_resource_types() do
     [
       "http://mu.semte.ch/vocabularies/ext/SysteemNotificatie"
@@ -269,7 +276,8 @@ defmodule Acl.UserGroups.Config do
               resource_types: public_static_data() ++
               public_codelists() ++
               system_resource_types() ++
-              user_account_resource_types() # required to list mock accounts for unauthenticated users
+              user_account_resource_types() ++ # required to list mock accounts for unauthenticated users
+              themis_export_types()
             } },
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/sessions",

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -218,5 +218,26 @@ export default [
         gracePeriod: 1000
       }
     };
-  })
+  }),
+  /* Themis export: TTL to delta */
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status'
+      },
+      object: {
+        type: 'uri',
+        value: 'http://redpencil.data.gift/ttl-to-delta-tasks/8C7E9155-B467-49A4-B047-7764FE5401F7'
+      }
+    },
+    callback: {
+      url: 'http://ttl-to-delta/delta', method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true
+    }
+  }
 ];

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -149,6 +149,24 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://agenda-approve/agendas/" <> agenda_id
   end
 
+  ### Themis export
+
+  post "/meetings/:meeting_id/themis-export" do
+    Proxy.forward conn, [], "http://themis-export/meetings/" <> meeting_id <> "/publication-activities"
+  end
+
+  get "/public-export-jobs/*path" do
+    Proxy.forward conn, path, "http://themis-export/public-export-jobs/"
+  end
+
+  get "/publications/*path" do
+    Proxy.forward conn, path, "http://publication-producer/files/"
+  end
+
+  get "/public-files/*path" do
+    Proxy.forward conn, path, "http://public-file/files/"
+  end
+
 
   ### Authentication
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -135,3 +135,11 @@ services:
     restart: "no"
   docx-conversion:
     restart: "no"
+  public-file:
+    restart: "no"
+  themis-export:
+    restart: "no"
+  ttl-to-delta:
+    restart: "no"
+  publication-producer:
+    restart: "no"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,6 +14,15 @@ services:
   file:
     volumes:
       - ./testdata/files:/share
+  public-file:
+    volumes:
+      - ./testdata/files:/share
+  themis-export:
+    volumes:
+      - ./testdata/files:/share
+  ttl-to-delta:
+    volumes:
+      - ./testdata/files:/share
   docx-conversion:
     volumes:
       - ./testdata/files:/share

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -340,3 +340,39 @@ services:
     restart: always
     labels:
       - "logging=true"
+  public-file:
+    image: kanselarij/public-file-service:4.2.1
+    environment:
+      MU_SPARQL_ENDPOINT: "http://triplestore:8890/sparql"
+      MU_APPLICATION_GRAPH: "http://mu.semte.ch/graphs/organizations/kanselarij"
+    volumes:
+      - ./data/files:/share
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
+  themis-export:
+    image: kanselarij/themis-export-service:2.5.2
+    environment:
+      MU_SPARQL_ENDPOINT: "http://database:8890/sparql" # database for results for which delta's must be generated
+      VIRTUOSO_SPARQL_ENDPOINT: "http://triplestore:8890/sparql" # database for intermediate results and to export data from
+    volumes:
+      - ./data/files:/share
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
+  ttl-to-delta:
+    image: redpencil/ttl-to-delta:1.0.1
+    volumes:
+      - ./data/files:/share
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
+  publication-producer:
+    image: kanselarij/themis-publication-producer:1.1.0
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging


### PR DESCRIPTION
Add the services from the [Themis export stack](https://github.com/kanselarij-vlaanderen/app-themis-export) to the Kaleidos stack. This should make deployments easier and remove certain risks (e.g. forgetting to update app-themis-export when upgrading Kaleidos).

The 4 main services are added to the stack and the configuration is merged (dispatcher, delta rules, authorization). Some of the stack documentation is added to the Kaleidos README to explain what the services do.

After this PR is merged I believe the export stack's repo can be archived.

Related PRs:
- [x] https://github.com/kanselarij-vlaanderen/themis-export-service/pull/15