### PR TITLE
KAS-3797: Slow government domain requests

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -350,11 +350,11 @@ defmodule Dispatcher do
   end
 
   match "/publication-statuses/*path", @json_service do
-    Proxy.forward conn, path, "http://cache/publication-statuses/"
+    Proxy.forward conn, path, "http://forever-cache/publication-statuses/"
   end
 
   get "/urgency-levels/*path", @json_service do
-    Proxy.forward conn, path, "http://cache/urgency-levels/"
+    Proxy.forward conn, path, "http://forever-cache/urgency-levels/"
   end
 
   match "/publication-status-changes/*path", @json_service do
@@ -362,11 +362,11 @@ defmodule Dispatcher do
   end
 
   get "/publication-modes/*path", @json_service do
-    Proxy.forward conn, path, "http://cache/publication-modes/"
+    Proxy.forward conn, path, "http://forever-cache/publication-modes/"
   end
 
   match "/regulation-types/*path", @json_service do
-    Proxy.forward conn, path, "http://cache/regulation-types/"
+    Proxy.forward conn, path, "http://forever-cache/regulation-types/"
   end
 
   match "/request-activities/*path", @json_service do

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -238,10 +238,10 @@ defmodule Dispatcher do
   end
 
   get "/concepts/*path", @json_service do
-    Proxy.forward conn, path, "http://cache/concepts/"
+    Proxy.forward conn, path, "http://forever-cache/concepts/"
   end
   get "/concept-schemes/*path", @json_service do
-    Proxy.forward conn, path, "http://cache/concept-schemes/"
+    Proxy.forward conn, path, "http://forever-cache/concept-schemes/"
   end
   match "/mandatees/*path", @json_service do
     Proxy.forward conn, path, "http://cache/mandatees/"

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -65,6 +65,8 @@ services:
       ENABLE_CONCEPTS_CACHE: "true"
   cache:
     restart: "no"
+  forever-cache:
+    restart: "no"
   resource:
     restart: "no"
   file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,12 +111,22 @@ services:
     labels:
       - "logging=true"
   cache-warmup:
-    image: kanselarij/cache-warmup-service:1.8.0
+    image: kanselarij/cache-warmup-service:feature-KAS-3797-slow-government-domain-requests
     logging: *default-logging
     restart: always
     labels:
       - "logging=true"
+    environment:
+      CONCEPT_BACKEND_URL: "http://forever-cache/"
   cache:
+    image: semtech/mu-cache:2.0.1
+    links:
+      - resource:backend
+    logging: *default-logging
+    restart: always
+    labels:
+      - "logging=true"
+  forever-cache:
     image: semtech/mu-cache:2.0.1
     links:
       - resource:backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     labels:
       - "logging=true"
   cache-warmup:
-    image: kanselarij/cache-warmup-service:feature-KAS-3797-slow-government-domain-requests
+    image: kanselarij/cache-warmup-service:1.9.0
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
Adds an extra "forever cache" that never gets invalidated to the stack. This is used for the concepts and concept schemes because they're static data and we want to prevent ever busting the cache (as some calls are pretty slow).

Related PRs:
- [ ] https://github.com/kanselarij-vlaanderen/cache-warmup-service/pull/11

Jenkins:
- http://kal-kastaar.s.redpencil.io:8080/job/kaleidos/job/custom_frontend_backend_combination/344/

Note: using `semtech/mu-cl-resource:feature-contstruct-based-fetches` lowered the request time considerable (from ~22s per batch to ~12s).