### PR TITLE
KAS-3929: Relink (some) agendas and agendaitems

### DIFF
--- a/config/migrations/20230315090808-relink-unlinked-agendas.sparql
+++ b/config/migrations/20230315090808-relink-unlinked-agendas.sparql
@@ -1,0 +1,21 @@
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+INSERT { GRAPH ?g { ?nieuwereAgenda prov:wasRevisionOf ?oudereAgenda } }
+WHERE {
+  VALUES ( ?nieuwereVersie ?oudereVersie ) {
+    ( "F" "E" )
+    ( "E" "D" )
+    ( "D" "C" )
+    ( "C" "B" )
+    ( "B" "A" )
+  }
+
+  GRAPH ?g {
+    ?nieuwereAgenda besluitvorming:volgnummer ?nieuwereVersie ;
+                   besluitvorming:isAgendaVoor ?meeting .
+    ?oudereAgenda besluitvorming:isAgendaVoor ?meeting ;
+                  besluitvorming:volgnummer ?oudereVersie .
+    FILTER NOT EXISTS { ?nieuwereAgenda prov:wasRevisionOf ?oudereAgenda }
+  }
+}

--- a/config/migrations/20230315090816-relink-unlinked-agendaitems.sparql
+++ b/config/migrations/20230315090816-relink-unlinked-agendaitems.sparql
@@ -1,0 +1,29 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+
+INSERT { GRAPH ?g { ?nieuwereAgendapunt prov:wasRevisionOf ?oudereAgendapunt } }
+WHERE {
+  VALUES ( ?nieuwereVersie ?oudereVersie ) {
+    ( "F" "E" )
+    ( "E" "D" )
+    ( "D" "C" )
+    ( "C" "B" )
+    ( "B" "A" )
+  }
+
+  GRAPH ?g {
+    ?agendering besluitvorming:vindtPlaatsTijdens ?subcase ;
+                besluitvorming:genereertAgendapunt ?nieuwereAgendapunt , ?oudereAgendapunt .
+
+    ?nieuwereAgenda dct:hasPart ?nieuwereAgendapunt ;
+                    besluitvorming:isAgendaVoor ?meeting ;
+                    besluitvorming:volgnummer ?nieuwereVersie .
+
+    ?oudereAgenda dct:hasPart ?oudereAgendapunt ;
+                  besluitvorming:isAgendaVoor ?meeting ;
+                  besluitvorming:volgnummer ?oudereVersie .
+
+    FILTER NOT EXISTS { ?nieuwereAgendapunt prov:wasRevisionOf ?oudereAgendapunt }
+  }
+}


### PR DESCRIPTION
We should no longer have agendas and agendaitems that are revisions of each other without being internally linked.

NOTE: The first agendaitem of an agenda does not have an agenda-activity, because of that they're left unlinked. Another solution (based on title matching perhaps?) must be found for those.