### PR TITLE
KAS-3980: Signing graph permissions

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -438,6 +438,7 @@ defmodule Acl.UserGroups.Config do
         access: access_by_role(
           admin_roles()
           ++ secretarie_roles()
+          ++ kort_bestek_roles()
           ++ minister_roles()
           ++ kabinet_dossierbeheerder_roles()
           ++ kabinet_medewerker_roles()
@@ -457,6 +458,7 @@ defmodule Acl.UserGroups.Config do
         access: access_by_role(
           admin_roles()
           ++ secretarie_roles()
+          ++ kort_bestek_roles()
           ++ minister_roles()
           ++ kabinet_dossierbeheerder_roles()
         ),

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -172,6 +172,7 @@ defmodule Acl.UserGroups.Config do
       "http://mu.semte.ch/vocabularies/ext/handtekenen/Markeringsactiviteit",
       "http://mu.semte.ch/vocabularies/ext/handtekenen/Voorbereidingsactiviteit",
       "http://mu.semte.ch/vocabularies/ext/handtekenen/Handtekenactiviteit",
+      "http://mu.semte.ch/vocabularies/ext/handtekenen/Goedkeuringsactiviteit",
       "http://mu.semte.ch/vocabularies/ext/handtekenen/Weigeractiviteit",
       "http://mu.semte.ch/vocabularies/ext/handtekenen/AnnulatieActiviteit",
       "http://mu.semte.ch/vocabularies/ext/handtekenen/Afrondingsactiviteit",

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -176,7 +176,6 @@ defmodule Acl.UserGroups.Config do
       "http://mu.semte.ch/vocabularies/ext/handtekenen/Weigeractiviteit",
       "http://mu.semte.ch/vocabularies/ext/handtekenen/AnnulatieActiviteit",
       "http://mu.semte.ch/vocabularies/ext/handtekenen/Afrondingsactiviteit",
-      "http://mu.semte.ch/vocabularies/ext/handtekenen/GetekendStuk",
       "http://mu.semte.ch/vocabularies/ext/signinghub/Document",
       "http://www.w3.org/ns/person#Person",
       "https://data.vlaanderen.be/ns/besluitvorming#Beslissingsactiviteit"

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -219,20 +219,6 @@ defmodule Acl.UserGroups.Config do
     ]
   end
 
-  defp sign_flow_types() do
-    [
-      "http://mu.semte.ch/vocabularies/ext/handtekenen/Handtekenaangelegenheid",
-      "http://mu.semte.ch/vocabularies/ext/handtekenen/HandtekenProcedurestap",
-      "http://mu.semte.ch/vocabularies/ext/handtekenen/Markeringsactiviteit",
-      "http://mu.semte.ch/vocabularies/ext/handtekenen/Voorbereidingsactiviteit",
-      "http://mu.semte.ch/vocabularies/ext/handtekenen/Handtekenactiviteit",
-      "http://mu.semte.ch/vocabularies/ext/handtekenen/Weigeractiviteit",
-      "http://mu.semte.ch/vocabularies/ext/handtekenen/AnnulatieActiviteit",
-      "http://mu.semte.ch/vocabularies/ext/handtekenen/Afrondingsactiviteit",
-      "http://mu.semte.ch/vocabularies/ext/handtekenen/GetekendStuk",
-    ]
-  end
-
   defp system_resource_types() do
     [
       "http://mu.semte.ch/vocabularies/ext/SysteemNotificatie"
@@ -353,8 +339,7 @@ defmodule Acl.UserGroups.Config do
                 generic_besluitvorming_resource_types() ++
                 document_resource_types() ++
                 file_bundling_resource_types() ++
-                publication_resource_types() ++
-                sign_resource_types()
+                publication_resource_types()
             }
           },
           %GraphSpec{
@@ -376,8 +361,7 @@ defmodule Acl.UserGroups.Config do
             constraint: %ResourceConstraint{
               resource_types: generic_besluitvorming_resource_types() ++
                 document_resource_types() ++
-                publication_resource_types() ++
-                sign_resource_types()
+                publication_resource_types()
             }
           },
           %GraphSpec{
@@ -444,7 +428,7 @@ defmodule Acl.UserGroups.Config do
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/system/signing",
             constraint: %ResourceConstraint{
-              resource_types: sign_flow_types()
+              resource_types: sign_resource_types()
             }
           }
         ]
@@ -462,7 +446,7 @@ defmodule Acl.UserGroups.Config do
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/system/signing",
             constraint: %ResourceConstraint{
-              resource_types: sign_flow_types()
+              resource_types: sign_resource_types()
             }
           }
         ]

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -40,13 +40,18 @@ defmodule Acl.UserGroups.Config do
 
   defp minister_roles do
     [
-      "<http://themis.vlaanderen.be/id/gebruikersrol/01ace9e0-f810-474e-b8e0-f578ff1e230d>" # minister
+      "<http://themis.vlaanderen.be/id/gebruikersrol/01ace9e0-f810-474e-b8e0-f578ff1e230d>" # minister and kabinetchef
     ]
   end
 
-  defp kabinet_roles do
+  defp kabinet_dossierbeheerder_roles do
     [
       "<http://themis.vlaanderen.be/id/gebruikersrol/6bcebe59-0cb5-4c5e-ab40-ca98b65887a4>", # kabinet dossierbeheerder
+    ]
+  end
+
+  defp kabinet_medewerker_roles do
+    [
       "<http://themis.vlaanderen.be/id/gebruikersrol/33dbca4a-7e57-41d2-a26c-aedef422ff84>" # kabinet medewerker
     ]
   end
@@ -372,7 +377,10 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-minister-read",
         useage: [:read, :write, :read_for_write],
-        access: access_by_role(minister_roles()),
+        access: access_by_role(
+          minister_roles()
+          ++ kabinet_dossierbeheerder_roles() # Technically this spec is too broad for dossierbeheerders, but we add extra checks down the line
+        ),
         graphs: [
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/organizations/minister",
@@ -385,7 +393,7 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "o-intern-regering-read",
         useage: [:read, :write, :read_for_write],
-        access: access_by_role(kabinet_roles()),
+        access: access_by_role(kabinet_medewerker_roles()),
         graphs: [
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/organizations/intern-regering",

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -219,6 +219,20 @@ defmodule Acl.UserGroups.Config do
     ]
   end
 
+  defp sign_flow_types() do
+    [
+      "http://mu.semte.ch/vocabularies/ext/handtekenen/Handtekenaangelegenheid",
+      "http://mu.semte.ch/vocabularies/ext/handtekenen/HandtekenProcedurestap",
+      "http://mu.semte.ch/vocabularies/ext/handtekenen/Markeringsactiviteit",
+      "http://mu.semte.ch/vocabularies/ext/handtekenen/Voorbereidingsactiviteit",
+      "http://mu.semte.ch/vocabularies/ext/handtekenen/Handtekenactiviteit",
+      "http://mu.semte.ch/vocabularies/ext/handtekenen/Weigeractiviteit",
+      "http://mu.semte.ch/vocabularies/ext/handtekenen/AnnulatieActiviteit",
+      "http://mu.semte.ch/vocabularies/ext/handtekenen/Afrondingsactiviteit",
+      "http://mu.semte.ch/vocabularies/ext/handtekenen/GetekendStuk",
+    ]
+  end
+
   defp system_resource_types() do
     [
       "http://mu.semte.ch/vocabularies/ext/SysteemNotificatie"
@@ -412,6 +426,43 @@ defmodule Acl.UserGroups.Config do
             graph: "http://mu.semte.ch/graphs/organizations/intern-overheid",
             constraint: %ResourceConstraint{
               resource_types: file_bundling_resource_types()
+            }
+          }
+        ]
+      },
+      %GroupSpec{
+        name: "sign-flow-read",
+        useage: [:read],
+        access: access_by_role(
+          admin_roles()
+          ++ secretarie_roles()
+          ++ minister_roles()
+          ++ kabinet_dossierbeheerder_roles()
+          ++ kabinet_medewerker_roles()
+        ),
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/system/signing",
+            constraint: %ResourceConstraint{
+              resource_types: sign_flow_types()
+            }
+          }
+        ]
+      },
+      %GroupSpec{
+        name: "sign-flow-write",
+        useage: [:write, :read_for_write],
+        access: access_by_role(
+          admin_roles()
+          ++ secretarie_roles()
+          ++ minister_roles()
+          ++ kabinet_dossierbeheerder_roles()
+        ),
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/system/signing",
+            constraint: %ResourceConstraint{
+              resource_types: sign_flow_types()
             }
           }
         ]

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -473,10 +473,6 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/sign-completion-activities/"
   end
 
-  match "/signed-pieces/*path", @json_service do
-    Proxy.forward conn, path, "http://cache/signed-pieces/"
-  end
-
   get "/signing-flows/:signing_flow_id/pieces", @json_service do
     Proxy.forward conn, [], "http://digital-signing/signing-flows/" <> signing_flow_id <> "/pieces"
   end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -457,6 +457,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/sign-signing-activities/"
   end
 
+  match "/sign-approval-activities/*path", @json_service do
+    Proxy.forward conn, path, "http://cache/sign-approval-activities/"
+  end
+
   match "/sign-refusal-activities/*path", @json_service do
     Proxy.forward conn, path, "http://cache/sign-refusal-activities/"
   end
@@ -477,8 +481,8 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://digital-signing/signing-flows/" <> signing_flow_id <> "/pieces"
   end
 
-  post "/signing-flows/:signing_flow_id/upload-document-to-signinghub", @json_service do
-    Proxy.forward conn, [], "http://digital-signing/signing-flows/" <> signing_flow_id <> "/upload-document-to-signinghub"
+  post "/signing-flows/:signing_flow_id/upload-to-signinghub", @json_service do
+    Proxy.forward conn, [], "http://digital-signing/signing-flows/" <> signing_flow_id <> "/upload-to-signinghub"
   end
 
   post "/sign-flows/:signing_flow_id/pieces/:piece_id/signers", @json_service do

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -437,6 +437,10 @@ defmodule Dispatcher do
   end
 
   # SIGN FLOW
+  match "/sign-flows/:signing_flow_id/pieces/:piece_id/signinghub-url", @json_service do
+    Proxy.forward conn, [], "http://digital-signing/signing-flows/" <> signing_flow_id <> "/pieces/" <> piece_id <> "/signinghub-url"
+  end
+
   match "/sign-flows/*path", @json_service do
     Proxy.forward conn, path, "http://cache/sign-flows/"
   end

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -31,6 +31,11 @@
             (piece                      :via      ,(s-prefix "pav:previousVersion")
                                         :inverse t
                                         :as "next-piece")
+            (piece                      :via      ,(s-prefix "sign:ongetekendStuk") ;; instead of using signed-piece
+                                        :as "unsigned-piece")
+            (piece                      :via      ,(s-prefix "sign:ongetekendStuk") ;; instead of using signed-piece
+                                        :inverse t
+                                        :as "signed-piece")
             (subcase                    :via ,(s-prefix "ext:bevatReedsBezorgdeDocumentversie") ;; should be hasMany, not used in frontend yet
                                         :inverse t
                                         :as "linked-subcase")
@@ -66,9 +71,6 @@
             (sign-marking-activity      :via ,(s-prefix "sign:gemarkeerdStuk")
                                         :inverse t
                                         :as "sign-marking-activity")
-            (signed-piece               :via ,(s-prefix "sign:ongetekendStuk")
-                                        :inverse t
-                                        :as "signed-piece")
             (submisison-activity        :via ,(s-prefix "prov:generated")
                                         :inverse t
                                         :as "submission-activity")

--- a/config/resources/handtekening-domain.json
+++ b/config/resources/handtekening-domain.json
@@ -74,6 +74,10 @@
           "type": "string",
           "predicate": "dct:title"
         },
+        "notified": {
+          "type": "uri-set",
+          "predicate": "sign:genotificeerde"
+        },
         "start-date": {
           "type": "datetime",
           "predicate": "dossier:Procedurestap.startdatum"
@@ -105,6 +109,12 @@
         "sign-signing-activities": {
           "predicate": "sign:handtekeningVindtPlaatsTijdens",
           "target": "sign-signing-activity",
+          "cardinality": "many",
+          "inverse": true
+        },
+        "sign-approval-activities": {
+          "predicate": "sign:goedkeuringVindtPlaatsTijdens",
+          "target": "sign-approval-activity",
           "cardinality": "many",
           "inverse": true
         },
@@ -203,6 +213,12 @@
           "target": "sign-signing-activity",
           "cardinality": "many",
           "inverse": true
+        },
+        "sign-approval-activities": {
+          "predicate": "sign:isGoedgekeurdDoor",
+          "target": "sign-approval-activity",
+          "cardinality": "many",
+          "inverse": true
         }
       },
       "features": ["include-uri"],
@@ -257,6 +273,43 @@
       "features": ["include-uri"],
       "new-resource-base": "http://themis.vlaanderen.be/id/handteken-handtekenactiviteit/"
     },
+    "sign-approval-activities": {
+      "name": "sign-approval-activity",
+      "class": "sign:Goedkeuringsactiviteit",
+      "attributes": {
+        "approver": {
+          "type": "url",
+          "predicate": "sign:goedkeurder"
+        },
+        "start-date": {
+          "type": "datetime",
+          "predicate": "dossier:Activiteit.startdatum"
+        },
+        "end-date": {
+          "type": "datetime",
+          "predicate": "dossier:Activiteit.einddatum"
+        }
+      },
+      "relationships": {
+        "sign-subcase": {
+          "predicate": "sign:goedkeuringVindtPlaatsTijdens",
+          "target": "sign-subcase",
+          "cardinality": "one"
+        },
+        "sign-preparation-activity": {
+          "predicate": "sign:isGoedgekeurdDoor",
+          "target": "sign-preparation-activity",
+          "cardinality": "one"
+        },
+        "sign-refusal-activity": {
+          "predicate": "sign:goedkeuringIsGeweigerdDoor",
+          "target": "sign-refusal-activity",
+          "cardinality": "one"
+        }
+      },
+      "features": ["include-uri"],
+      "new-resource-base": "http://themis.vlaanderen.be/id/handteken-goedkeuringsactiviteit/"
+    },
     "sign-refusal-activities": {
       "name": "sign-refusal-activity",
       "class": "sign:Weigeractiviteit",
@@ -284,6 +337,12 @@
         "sign-signing-activity": {
           "predicate": "sign:isGeweigerdDoor",
           "target": "sign-signing-activity",
+          "cardinality": "one",
+          "inverse": true
+        },
+        "sign-approval-activity": {
+          "predicate": "sign:goedkeuringIsGeweigerdDoor",
+          "target": "sign-approval-activity",
           "cardinality": "one",
           "inverse": true
         }
@@ -371,11 +430,6 @@
         }
       },
       "relationships": {
-        "unsigned-piece": {
-          "predicate": "sign:ongetekendStuk",
-          "target": "piece",
-          "cardinality": "one"
-        },
         "signed-file": {
           "predicate": "sign:getekendBestand",
           "target": "file",

--- a/config/resources/handtekening-domain.json
+++ b/config/resources/handtekening-domain.json
@@ -409,41 +409,12 @@
         },
         "signed-piece": {
           "predicate": "sign:getekendStuk",
-          "target": "signed-piece",
+          "target": "piece",
           "cardinality": "one"
         }
       },
       "features": ["include-uri"],
       "new-resource-base": "http://themis.vlaanderen.be/id/handteken-afrondingsactiviteit/"
-    },
-    "signed-pieces": {
-      "name": "signed-piece",
-      "class": "sign:GetekendStuk",
-      "attributes": {
-        "title": {
-          "type": "string",
-          "predicate": "dct:title"
-        },
-        "created": {
-          "type": "datetime",
-          "predicate": "dct:created"
-        }
-      },
-      "relationships": {
-        "signed-file": {
-          "predicate": "sign:getekendBestand",
-          "target": "file",
-          "cardinality": "one"
-        },
-        "sign-completion-activity": {
-          "predicate": "sign:getekendStuk",
-          "target": "sign-completion-activity",
-          "cardinality": "one",
-          "inverse": true
-        }
-      },
-      "features": ["include-uri"],
-      "new-resource-base": "http://themis.vlaanderen.be/id/getekend-stuk/"
     }
   }
 }

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -15,6 +15,8 @@
     ],
     [
       { "name": "secretarie", "variables": [] },
+      { "name": "sign-flow-read", "variables": [] },
+      { "name": "sign-flow-write", "variables": [] },
       { "name": "authenticated", "variables": [] },
       { "name": "public", "variables": [] },
       { "name": "clean", "variables": [] }
@@ -27,12 +29,15 @@
     ],
     [
       { "name": "o-minister-read", "variables": [] },
+      { "name": "sign-flow-write", "variables": [] },
+      { "name": "sign-flow-read", "variables": [] },
       { "name": "authenticated", "variables": [] },
       { "name": "public", "variables": [] },
       { "name": "clean", "variables": [] }
     ],
     [
       { "name": "o-intern-regering-read", "variables": [] },
+      { "name": "sign-flow-read", "variables": [] },
       { "name": "authenticated", "variables": [] },
       { "name": "public", "variables": [] },
       { "name": "clean", "variables": [] }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,7 +216,7 @@ services:
     labels:
       - "logging=true"
   file-bundling-job-creation:
-    image: kanselarij/file-bundling-job-creation-service:0.5.0
+    image: kanselarij/file-bundling-job-creation-service:0.5.1
     logging: *default-logging
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -404,3 +404,8 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  digital-signing:
+    image: kanselarij/digital-signing # Make sure to specify a tagged version here
+    volumes:
+      - ./data/files:/share
+    restart: always


### PR DESCRIPTION
# :warning: This is blocked by 

- [ ] https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1712 (https://kanselarij.atlassian.net/browse/KAS-3944)
- [x] https://github.com/kanselarij-vlaanderen/file-bundling-job-creation-service/pull/8
- [x]  https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1735

Kabinet roles are split up into kabinetdossierbeheerder and kabinetmedewerker. Kabinetdossierbeheerder has the same permissions as minister (and kabinetchef), but other checks across the app will handle that kabinetdossierbeheerders can only see vertrouwelijk documents from their minister.

Read & write access is granted to Admin, Secretarie, Minister (and KC), Kabinetdossierbeheerder. Write access is granted to Kabinetmedewerker.