### PR TITLE
KAS-3911: Fix users overview interface w.r.t. login time

### DIFF
--- a/config/migrations/20230317120000-set-login-activity-for-existing.sparql
+++ b/config/migrations/20230317120000-set-login-activity-for-existing.sparql
@@ -1,0 +1,44 @@
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/system/users> {
+    ?loginActivity a ext:LoginActivity ;
+      mu:uuid ?uuid ;
+      prov:startedAtTime ?loginTime ;
+      prov:wasAssociatedWith ?user .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?account a foaf:OnlineAccount .
+    ?user a foaf:Person ;
+      foaf:account ?account .
+    OPTIONAL { ?user dct:created ?created . }
+  }
+  VALUES (?g) {
+    (<http://mu.semte.ch/graphs/public>)
+    (<http://mu.semte.ch/graphs/system/users>)
+  }
+  BIND(STRUUID() AS ?uuid)
+  BIND(IRI(CONCAT('http://themis.vlaanderen.be/id/aanmeldingsactiviteit/', ?uuid)) AS ?loginActivity)
+  BIND(COALESCE(?created,
+    xsd:dateTime(
+        CONCAT(
+          STR(YEAR(NOW())), "-",
+          STR(MONTH(NOW())), "-",
+          STR(DAY(NOW())), "T",
+          STR(hours(now())), ":",
+          STR(minutes(now())), ":",
+          STR(FLOOR(seconds(now()))), "Z"
+        )
+      )
+    ) AS ?loginTime)
+  FILTER NOT EXISTS {
+    [ a ext:LoginActivity ] prov:wasAssociatedWith ?user .
+  }
+}

--- a/config/migrations/20230317120112-remove-duplicate-login-activities.sparql
+++ b/config/migrations/20230317120112-remove-duplicate-login-activities.sparql
@@ -1,0 +1,27 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+DELETE { GRAPH ?h { ?olderLoginActivity ?p ?o } }
+WHERE {
+  VALUES (?g) {
+    (<http://mu.semte.ch/graphs/public>)
+    (<http://mu.semte.ch/graphs/system/users>)
+  }
+  GRAPH ?g {
+    ?account a foaf:OnlineAccount .
+    ?user a foaf:Person ;
+      foaf:account ?account .
+  }
+  GRAPH ?h {
+    ?olderLoginActivity a ext:LoginActivity ;
+      prov:wasAssociatedWith ?user ;
+      prov:startedAtTime ?olderLoginTime .
+    ?newerLoginActivity a ext:LoginActivity ;
+      prov:wasAssociatedWith ?user ;
+      prov:startedAtTime ?newerLoginTime .
+    FILTER(?olderLoginTime < ?newerLoginTime)
+
+    ?olderLoginActivity ?p ?o .
+  }
+}


### PR DESCRIPTION
ACC (and maybe PROD?) has dummy accounts for the mock-login service (but isn't used). These accounts lack login activities, which breaks the pagination interface because mu-cl-resources is unable to properly sort on a missing value.
The added migration creates missing login activities, and removes any duplicate login activities as well.