### PR TITLE
KAS-4005: Add health-check endpoint that directly exposes resources service

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -31,6 +31,11 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://static-file/handleiding.pdf"
   end
 
+  ### Health check endpoint
+  get "/health-checks/*_path", @json_service do
+    forward conn, [], "http://resource/health-checks/"
+  end
+
   ### File conversion
 
   post "/files/:id/convert", @json_service do

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -37,6 +37,7 @@
 (read-domain-file "email-domain.lisp")
 (read-domain-file "generiek-domain.json")
 (read-domain-file "concept-domain.json")
+(read-domain-file "health-check.lisp")
 
 
 (defcall :get (base-path)

--- a/config/resources/health-check.lisp
+++ b/config/resources/health-check.lisp
@@ -1,0 +1,4 @@
+(define-resource health-check ()
+  :class (s-prefix "ext:HealthCheck")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/health-check/")
+  :on-path "health-checks")


### PR DESCRIPTION
All other endpoints go through the cache, which doesn't necessarily fail as soon as resource fails. Therefore we add the health check endpoint which directly goes through to mu-cl-resources.