### PR TITLE
fix: don't write prov:Activity to system/users graph

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -214,7 +214,6 @@ defmodule Acl.UserGroups.Config do
 
   defp user_activity_types() do
     [
-      "http://www.w3.org/ns/prov#Activity",
       "http://mu.semte.ch/vocabularies/ext/LoginActivity"
     ]
   end

--- a/config/resources/users-domain.json
+++ b/config/resources/users-domain.json
@@ -148,7 +148,6 @@
     "login-activities": {
       "name": "login-activity",
       "class": "ext:LoginActivity",
-      "super": ["activity"],
       "attributes": {
         "start-date": {
           "type": "datetime",


### PR DESCRIPTION
Execute the following query on ACC to fix existing agendas:
```
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
DELETE WHERE {
  GRAPH <http://mu.semte.ch/graphs/system/users> {
    ?themisPublicationActivity a ext:ThemisPublicationActivity .
    ?themisPublicationActivity ?p ?o .
  }
}
```

Can we do it directly on mu-auth? :thinking: 