### PR TITLE
KAS-4130 Added signflow status codelist

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -359,5 +359,22 @@ export default [
       gracePeriod: 5000,
       ignoreFromSelf: true
     }
+  },
+  {
+    match: {
+      predicate: { // When the signing or approval activities start
+        type: 'uri',
+        value: 'https://data.vlaanderen.be/ns/dossier#Activiteit.startdatum'
+      }
+    },
+    callback: {
+      url: 'http://signflow-status-sync/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 5000,
+      ignoreFromSelf: true
+    }
   }
 ];

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -239,5 +239,125 @@ export default [
       gracePeriod: 1000,
       ignoreFromSelf: true
     }
+  },
+  /* Signflow activities lead to new status */
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://mu.semte.ch/vocabularies/ext/handtekenen/markeringVindtPlaatsTijdens'
+      }
+    },
+    callback: {
+      url: 'http://signflow-status-sync/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 5000,
+      ignoreFromSelf: true
+    }
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://mu.semte.ch/vocabularies/ext/handtekenen/voorbereidingVindtPlaatsTijdens'
+      }
+    },
+    callback: {
+      url: 'http://signflow-status-sync/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 5000,
+      ignoreFromSelf: true
+    }
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://mu.semte.ch/vocabularies/ext/handtekenen/handtekeningVindtPlaatsTijdens'
+      }
+    },
+    callback: {
+      url: 'http://signflow-status-sync/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 5000,
+      ignoreFromSelf: true
+    }
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://mu.semte.ch/vocabularies/ext/handtekenen/goedkeuringVindtPlaatsTijdens'
+      }
+    },
+    callback: {
+      url: 'http://signflow-status-sync/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 5000,
+      ignoreFromSelf: true
+    }
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://mu.semte.ch/vocabularies/ext/handtekenen/weigeringVindtPlaatsTijdens'
+      }
+    },
+    callback: {
+      url: 'http://signflow-status-sync/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 5000,
+      ignoreFromSelf: true
+    }
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://mu.semte.ch/vocabularies/ext/handtekenen/annulatieVindtPlaatsTijdens'
+      }
+    },
+    callback: {
+      url: 'http://signflow-status-sync/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 5000,
+      ignoreFromSelf: true
+    }
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://mu.semte.ch/vocabularies/ext/handtekenen/afrondingVindtPlaatsTijdens'
+      }
+    },
+    callback: {
+      url: 'http://signflow-status-sync/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 5000,
+      ignoreFromSelf: true
+    }
   }
 ];

--- a/config/migrations/20230607150000-add-signflow-status-codelist.graph
+++ b/config/migrations/20230607150000-add-signflow-status-codelist.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20230607150000-add-signflow-status-codelist.ttl
+++ b/config/migrations/20230607150000-add-signflow-status-codelist.ttl
@@ -1,0 +1,42 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix thConceptScheme: <http://themis.vlaanderen.be/id/concept-scheme/> .
+
+thConceptScheme:ebfe253c-0537-11ee-bb35-ee395168dcf7 a skos:ConceptScheme ;
+  mu:uuid "ebfe253c-0537-11ee-bb35-ee395168dcf7" ;
+  skos:prefLabel "HandtekenStatussen"@nl .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/f6a60072-0537-11ee-bb35-ee395168dcf7> a skos:Concept ;
+    mu:uuid "f6a60072-0537-11ee-bb35-ee395168dcf7" ;
+    skos:inScheme thConceptScheme:ebfe253c-0537-11ee-bb35-ee395168dcf7 ;
+    skos:prefLabel "Voor te bereiden"@nl .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/1dd296c2-053a-11ee-bb35-ee395168dcf7> a skos:Concept ;
+    mu:uuid "1dd296c2-053a-11ee-bb35-ee395168dcf7" ;
+    skos:inScheme thConceptScheme:ebfe253c-0537-11ee-bb35-ee395168dcf7 ;
+    skos:prefLabel "Verstuurd"@nl .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/2fd72150-0538-11ee-bb35-ee395168dcf7> a skos:Concept ;
+    mu:uuid "2fd72150-0538-11ee-bb35-ee395168dcf7" ;
+    skos:inScheme thConceptScheme:ebfe253c-0537-11ee-bb35-ee395168dcf7 ;
+    skos:prefLabel "Goed te keuren"@nl .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/47508452-0538-11ee-bb35-ee395168dcf7> a skos:Concept ;
+    mu:uuid "47508452-0538-11ee-bb35-ee395168dcf7" ;
+    skos:inScheme thConceptScheme:ebfe253c-0537-11ee-bb35-ee395168dcf7 ;
+    skos:prefLabel "Te handtekenen"@nl .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/29d4e7d2-0539-11ee-bb35-ee395168dcf7> a skos:Concept ;
+    mu:uuid "29d4e7d2-0539-11ee-bb35-ee395168dcf7" ;
+    skos:inScheme thConceptScheme:ebfe253c-0537-11ee-bb35-ee395168dcf7 ;
+    skos:prefLabel "Getekend"@nl .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/3128aae6-0539-11ee-bb35-ee395168dcf7> a skos:Concept ;
+    mu:uuid "3128aae6-0539-11ee-bb35-ee395168dcf7" ;
+    skos:inScheme thConceptScheme:ebfe253c-0537-11ee-bb35-ee395168dcf7 ;
+    skos:prefLabel "Geweigerd"@nl .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/2d043722-053a-11ee-bb35-ee395168dcf7> a skos:Concept ;
+    mu:uuid "2d043722-053a-11ee-bb35-ee395168dcf7" ;
+    skos:inScheme thConceptScheme:ebfe253c-0537-11ee-bb35-ee395168dcf7 ;
+    skos:prefLabel "Geannuleerd"@nl .

--- a/config/migrations/20230607150100-sync-existing-signing-statuses.sparql
+++ b/config/migrations/20230607150100-sync-existing-signing-statuses.sparql
@@ -13,8 +13,8 @@ WHERE {
     SELECT ?signflow ?oldStatus
       (COALESCE (?markingActivity, 0) AS ?markingActivity)
       (COALESCE (?preparationActivity, 0) AS ?preparationActivity)
-      (COUNT(?signingActivity) AS ?signingActivities)
-      (COUNT(?approvalActivity) AS ?approvalActivities)
+      (COUNT(?signingStartDate) AS ?signingStartDates)
+      (COUNT(?approvalStartDate) AS ?approvalStartDates)
       (COUNT(?refusalActivity) AS ?refusalActivities)
       (COALESCE (?cancellationActivity, 0) AS ?cancellationActivity)
       (COALESCE (?completionActivity, 0) AS ?completionActivity)
@@ -25,8 +25,14 @@ WHERE {
         OPTIONAL { ?signflow <http://www.w3.org/ns/adms#status> ?oldStatus }
         OPTIONAL { ?markingActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/markeringVindtPlaatsTijdens> ?signSubcase . }
         OPTIONAL { ?preparationActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/voorbereidingVindtPlaatsTijdens> ?signSubcase . }
-        OPTIONAL { ?approvalActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/goedkeuringVindtPlaatsTijdens> ?signSubcase . }
-        OPTIONAL { ?signingActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/handtekeningVindtPlaatsTijdens> ?signSubcase . }
+        OPTIONAL {
+          ?approvalActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/goedkeuringVindtPlaatsTijdens> ?signSubcase .
+          ?approvalActivity <https://data.vlaanderen.be/ns/dossier#Activiteit.startdatum> ?approvalStartDate .
+        }
+        OPTIONAL {
+          ?signingActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/handtekeningVindtPlaatsTijdens> ?signSubcase .
+          ?signingActivity <https://data.vlaanderen.be/ns/dossier#Activiteit.startdatum> ?signingStartDate .
+        }
         OPTIONAL { ?refusalActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/weigeringVindtPlaatsTijdens> ?signSubcase . }
         OPTIONAL { ?cancellationActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/annulatieVindtPlaatsTijdens> ?signSubcase . }
         OPTIONAL { ?completionActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/afrondingVindtPlaatsTijdens> ?signSubcase . }
@@ -37,8 +43,8 @@ WHERE {
     IF(?refusalActivities > 0, <http://themis.vlaanderen.be/id/handtekenstatus/3128aae6-0539-11ee-bb35-ee395168dcf7>,
       IF(?cancellationActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/2d043722-053a-11ee-bb35-ee395168dcf7>,
         IF(?completionActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/29d4e7d2-0539-11ee-bb35-ee395168dcf7>,
-          IF(?signingActivities > 0, <http://themis.vlaanderen.be/id/handtekenstatus/47508452-0538-11ee-bb35-ee395168dcf7>,
-            IF(?approvalActivities > 0, <http://themis.vlaanderen.be/id/handtekenstatus/2fd72150-0538-11ee-bb35-ee395168dcf7>,
+          IF(?signingStartDates > 0, ${sparqlEscapeUri(SIGNFLOW_STATUSES.TO_BE_SIGNED)},
+            IF(?approvalStartDates > 0, ${sparqlEscapeUri(SIGNFLOW_STATUSES.TO_BE_APPROVED)},
               IF(?preparationActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/1dd296c2-053a-11ee-bb35-ee395168dcf7>,
                 IF(?markingActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/f6a60072-0537-11ee-bb35-ee395168dcf7>, ?oldStatus)
               )

--- a/config/migrations/20230607150100-sync-existing-signing-statuses.sparql
+++ b/config/migrations/20230607150100-sync-existing-signing-statuses.sparql
@@ -11,13 +11,13 @@ INSERT {
 WHERE {
   {
     SELECT ?signflow ?oldStatus
-      COALESCE (?markingActivity, 0) AS ?markingActivity
-      COALESCE (?preparationActivity, 0) AS ?preparationActivity
-      COUNT(?signingActivity) AS ?signingActivities
-      COUNT(?approvalActivity) AS ?approvalActivities
-      COUNT(?refusalActivity) AS ?refusalActivities
-      COALESCE (?cancellationActivity, 0) AS ?cancellationActivity
-      COALESCE (?completionActivity, 0) AS ?completionActivity
+      (COALESCE (?markingActivity, 0) AS ?markingActivity)
+      (COALESCE (?preparationActivity, 0) AS ?preparationActivity)
+      (COUNT(?signingActivity) AS ?signingActivities)
+      (COUNT(?approvalActivity) AS ?approvalActivities)
+      (COUNT(?refusalActivity) AS ?refusalActivities)
+      (COALESCE (?cancellationActivity, 0) AS ?cancellationActivity)
+      (COALESCE (?completionActivity, 0) AS ?completionActivity)
     WHERE {
       GRAPH <http://mu.semte.ch/graphs/system/signing> {
         ?signflow a <http://mu.semte.ch/vocabularies/ext/handtekenen/Handtekenaangelegenheid> ;

--- a/config/migrations/20230607150100-sync-existing-signing-statuses.sparql
+++ b/config/migrations/20230607150100-sync-existing-signing-statuses.sparql
@@ -25,8 +25,8 @@ WHERE {
         OPTIONAL { ?signflow <http://www.w3.org/ns/adms#status> ?oldStatus }
         OPTIONAL { ?markingActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/markeringVindtPlaatsTijdens> ?signSubcase . }
         OPTIONAL { ?preparationActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/voorbereidingVindtPlaatsTijdens> ?signSubcase . }
-        OPTIONAL { ?signingActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/handtekeningVindtPlaatsTijdens> ?signSubcase . }
         OPTIONAL { ?approvalActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/goedkeuringVindtPlaatsTijdens> ?signSubcase . }
+        OPTIONAL { ?signingActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/handtekeningVindtPlaatsTijdens> ?signSubcase . }
         OPTIONAL { ?refusalActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/weigeringVindtPlaatsTijdens> ?signSubcase . }
         OPTIONAL { ?cancellationActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/annulatieVindtPlaatsTijdens> ?signSubcase . }
         OPTIONAL { ?completionActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/afrondingVindtPlaatsTijdens> ?signSubcase . }
@@ -34,12 +34,14 @@ WHERE {
     }
   }
   BIND (
-    IF(?refusalActivities > 0, "Geweigerd",
-      IF(?completionActivity != 0, "Getekend",
-        IF(?signingActivities > 0, "Te handtekenen",
-          IF(?approvalActivities > 0, "Goed te keuren",
-            IF(?preparationActivity != 0, "Verstuurd",
-              IF(?markingActivity != 0, "Voor te bereiden", ?oldStatus)
+    IF(?refusalActivities > 0, <http://themis.vlaanderen.be/id/handtekenstatus/3128aae6-0539-11ee-bb35-ee395168dcf7>,
+      IF(?cancellationActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/2d043722-053a-11ee-bb35-ee395168dcf7>,
+        IF(?completionActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/29d4e7d2-0539-11ee-bb35-ee395168dcf7>,
+          IF(?signingActivities > 0, <http://themis.vlaanderen.be/id/handtekenstatus/47508452-0538-11ee-bb35-ee395168dcf7>,
+            IF(?approvalActivities > 0, <http://themis.vlaanderen.be/id/handtekenstatus/2fd72150-0538-11ee-bb35-ee395168dcf7>,
+              IF(?preparationActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/1dd296c2-053a-11ee-bb35-ee395168dcf7>,
+                IF(?markingActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/f6a60072-0537-11ee-bb35-ee395168dcf7>, ?oldStatus)
+              )
             )
           )
         )

--- a/config/migrations/20230607150100-sync-existing-signing-statuses.sparql
+++ b/config/migrations/20230607150100-sync-existing-signing-statuses.sparql
@@ -43,8 +43,8 @@ WHERE {
     IF(?refusalActivities > 0, <http://themis.vlaanderen.be/id/handtekenstatus/3128aae6-0539-11ee-bb35-ee395168dcf7>,
       IF(?cancellationActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/2d043722-053a-11ee-bb35-ee395168dcf7>,
         IF(?completionActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/29d4e7d2-0539-11ee-bb35-ee395168dcf7>,
-          IF(?signingStartDates > 0, ${sparqlEscapeUri(SIGNFLOW_STATUSES.TO_BE_SIGNED)},
-            IF(?approvalStartDates > 0, ${sparqlEscapeUri(SIGNFLOW_STATUSES.TO_BE_APPROVED)},
+          IF(?signingStartDates > 0, <http://themis.vlaanderen.be/id/handtekenstatus/47508452-0538-11ee-bb35-ee395168dcf7>,
+            IF(?approvalStartDates > 0, <http://themis.vlaanderen.be/id/handtekenstatus/2fd72150-0538-11ee-bb35-ee395168dcf7>,
               IF(?preparationActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/1dd296c2-053a-11ee-bb35-ee395168dcf7>,
                 IF(?markingActivity != 0, <http://themis.vlaanderen.be/id/handtekenstatus/f6a60072-0537-11ee-bb35-ee395168dcf7>, ?oldStatus)
               )

--- a/config/migrations/20230607150100-sync-existing-signing-statuses.sparql
+++ b/config/migrations/20230607150100-sync-existing-signing-statuses.sparql
@@ -1,0 +1,49 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/system/signing> {
+    ?signflow <http://www.w3.org/ns/adms#status> ?oldStatus .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/system/signing> {
+    ?signflow <http://www.w3.org/ns/adms#status> ?newStatus .
+  }
+}
+WHERE {
+  {
+    SELECT ?signflow ?oldStatus
+      COALESCE (?markingActivity, 0) AS ?markingActivity
+      COALESCE (?preparationActivity, 0) AS ?preparationActivity
+      COUNT(?signingActivity) AS ?signingActivities
+      COUNT(?approvalActivity) AS ?approvalActivities
+      COUNT(?refusalActivity) AS ?refusalActivities
+      COALESCE (?cancellationActivity, 0) AS ?cancellationActivity
+      COALESCE (?completionActivity, 0) AS ?completionActivity
+    WHERE {
+      GRAPH <http://mu.semte.ch/graphs/system/signing> {
+        ?signflow a <http://mu.semte.ch/vocabularies/ext/handtekenen/Handtekenaangelegenheid> ;
+                        <http://mu.semte.ch/vocabularies/ext/handtekenen/doorlooptHandtekening> ?signSubcase .
+        OPTIONAL { ?signflow <http://www.w3.org/ns/adms#status> ?oldStatus }
+        OPTIONAL { ?markingActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/markeringVindtPlaatsTijdens> ?signSubcase . }
+        OPTIONAL { ?preparationActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/voorbereidingVindtPlaatsTijdens> ?signSubcase . }
+        OPTIONAL { ?signingActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/handtekeningVindtPlaatsTijdens> ?signSubcase . }
+        OPTIONAL { ?approvalActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/goedkeuringVindtPlaatsTijdens> ?signSubcase . }
+        OPTIONAL { ?refusalActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/weigeringVindtPlaatsTijdens> ?signSubcase . }
+        OPTIONAL { ?cancellationActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/annulatieVindtPlaatsTijdens> ?signSubcase . }
+        OPTIONAL { ?completionActivity <http://mu.semte.ch/vocabularies/ext/handtekenen/afrondingVindtPlaatsTijdens> ?signSubcase . }
+      }
+    }
+  }
+  BIND (
+    IF(?refusalActivities > 0, "Geweigerd",
+      IF(?completionActivity != 0, "Getekend",
+        IF(?signingActivities > 0, "Te handtekenen",
+          IF(?approvalActivities > 0, "Goed te keuren",
+            IF(?preparationActivity != 0, "Verstuurd",
+              IF(?markingActivity != 0, "Voor te bereiden", ?oldStatus)
+            )
+          )
+        )
+      )
+    ) AS ?newStatus
+  )
+}

--- a/config/resources/handtekening-domain.json
+++ b/config/resources/handtekening-domain.json
@@ -37,6 +37,11 @@
         }
       },
       "relationships": {
+        "status": {
+          "predicate": "adms:status",
+          "target": "concept",
+          "cardinality": "one"
+        },
         "regulation-type": {
           "predicate": "sign:regelgevingType",
           "target": "regulation-type",

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -139,6 +139,9 @@ services:
     restart: "no"
   shortlist:
     restart: "no"
+  signflow-status-sync:
+    image: lblod/sink-service:1.0.0
+    restart: "no"
   public-file:
     restart: "no"
   themis-export:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -361,6 +361,9 @@ services:
     volumes:
       - ./data/files:/share
     restart: always
+  signflow-status-sync:
+    image: kanselarij/signflow-status-sync-service:0.0.1
+    restart: always
   #themis
   public-file:
     image: kanselarij/public-file-service:4.3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -362,7 +362,7 @@ services:
       - ./data/files:/share
     restart: always
   signflow-status-sync:
-    image: kanselarij/signflow-status-sync-service:0.0.1
+    image: kanselarij/signflow-status-sync-service:0.0.2
     restart: always
   #themis
   public-file:


### PR DESCRIPTION
Provisions for status concepts to be linked to sign flows.

Includes: 
1 migration (uuids were generated using SPARQL on ACCEPT)
1 model addition.
delta rules
new service in docker-compose.yml

Related PR: https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1770
Related PR: https://github.com/kanselarij-vlaanderen/signflow-status-sync-service/pull/1

Related service: https://github.com/kanselarij-vlaanderen/signflow-status-sync-service