### PR TITLE
fix: add migration to remove wrong cases and relink agendaitems

### DIFF
--- a/config/migrations/20230616102023-remove-wrong-cases-1.sparql
+++ b/config/migrations/20230616102023-remove-wrong-cases-1.sparql
@@ -1,0 +1,43 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX schema: <http://schema.org/>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX besluitvor: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    ?agendaActivity ?aaP ?aaO .
+
+    ?submissionActivity ?saP ?saO .
+
+    ?agendaitem ext:isGoedkeuringVanDeNotulen ?isApproval .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    ?agendaitem ext:isGoedkeuringVanDeNotulen "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    VALUES ?decisionmakingFlowId { "8D5686A8-411C-11ED-BB35-EE395168DCF7" "8C806F51-411C-11ED-BB35-EE395168DCF7" }
+    ?decisionmakingFlow mu:uuid ?decisionmakingFlowId .
+
+    ###
+    # Stuff we need to delete
+    ?case dossier:Dossier.isNeerslagVan ?decisionmakingFlow .
+    ?decisionmakingFlow dossier:doorloopt ?subcase .
+    ?agendaActivity besluitvor:vindtPlaatsTijdens ?subcase .
+    ?agendaActivity prov:wasInformedBy ?submissionActivity .
+
+    OPTIONAL { ?agendaActivity ?aaP ?aaO }
+
+    OPTIONAL { ?submissionActivity ?saP ?saO }
+    ###
+
+    ?agendaActivity besluitvor:genereertAgendapunt ?agendaitem .
+    ?agendaitem ext:isGoedkeuringVanDeNotulen ?isApproval .
+  }
+}

--- a/config/migrations/20230616102023-remove-wrong-cases-2.sparql
+++ b/config/migrations/20230616102023-remove-wrong-cases-2.sparql
@@ -9,26 +9,11 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 DELETE {
   GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
     ?decisionmakingFlow ?dcmfP ?dcmfO .
-   	?dcmfS ?dcmfP_ ?decisionmakingFlow .
 
     ?case ?cP ?cO .
-    ?cS ?cP_ ?case .
 
     ?subcase ?scP ?scO .
     ?scS ?scP_ ?subcase .
-
-    ?agendaActivity ?aaP ?aaO .
-    ?aaS ?aaP_ ?agendaActivity .
-
-    ?submissionActivity ?saP ?saO .
-    ?saS ?saP_ ?submissionActivity .
-
-    ?agendaitem ext:isGoedkeuringVanDeNotulen ?isApproval .
-  }
-}
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
-    ?agendaitem ext:isGoedkeuringVanDeNotulen "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
   }
 }
 WHERE {
@@ -40,26 +25,12 @@ WHERE {
     # Stuff we need to delete
     ?case dossier:Dossier.isNeerslagVan ?decisionmakingFlow .
     ?decisionmakingFlow dossier:doorloopt ?subcase .
-    ?agendaActivity besluitvor:vindtPlaatsTijdens ?subcase .
-    ?agendaActivity prov:wasInformedBy ?submissionActivity .
 
     OPTIONAL { ?decisionmakingFlow ?dcmfP ?dcmfO }
-   	OPTIONAL { ?dcmfS ?dcmfP_ ?decisionmakingFlow }
 
     OPTIONAL { ?case ?cP ?cO }
-    OPTIONAL { ?cS ?cP_ ?case }
 
     OPTIONAL { ?subcase ?scP ?scO }
     OPTIONAL { ?scS ?scP_ ?subcase }
-
-    OPTIONAL { ?agendaActivity ?aaP ?aaO }
-    OPTIONAL { ?aaS ?aaP_ ?agendaActivity }
-
-    OPTIONAL { ?submissionActivity ?saP ?saO }
-    OPTIONAL { ?saS ?saP_ ?submissionActivity }
-    ###
-
-    ?agendaActivity besluitvor:genereertAgendapunt ?agendaitem .
-    ?agendaitem ext:isGoedkeuringVanDeNotulen ?isApproval .
   }
 }

--- a/config/migrations/20230616102023-remove-wrong-cases.sparql
+++ b/config/migrations/20230616102023-remove-wrong-cases.sparql
@@ -4,6 +4,7 @@ PREFIX schema: <http://schema.org/>
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX besluitvor: <https://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
 
 DELETE {
   GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
@@ -19,16 +20,15 @@ DELETE {
     ?agendaActivity ?aaP ?aaO .
     ?aaS ?aaP_ ?agendaActivity .
 
-    ?agendaitem schema:position ?agendaitemPosition .
+    ?submissionActivity ?saP ?saO .
+    ?saS ?saP_ ?submissionActivity .
+
     ?agendaitem ext:isGoedkeuringVanDeNotulen ?isApproval .
-    ?otherAgendaitem schema:position ?otherAgendaitemPosition .
   }
 }
 INSERT {
   GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
-    ?agendaitem schema:position 1 .
     ?agendaitem ext:isGoedkeuringVanDeNotulen "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
-    ?otherAgendaitem schema:position ?newOtherAgendaitemPosition .
   }
 }
 WHERE {
@@ -41,6 +41,7 @@ WHERE {
     ?case dossier:Dossier.isNeerslagVan ?decisionmakingFlow .
     ?decisionmakingFlow dossier:doorloopt ?subcase .
     ?agendaActivity besluitvor:vindtPlaatsTijdens ?subcase .
+    ?agendaActivity prov:wasInformedBy ?submissionActivity .
 
     OPTIONAL { ?decisionmakingFlow ?dcmfP ?dcmfO }
    	OPTIONAL { ?dcmfS ?dcmfP_ ?decisionmakingFlow }
@@ -53,20 +54,12 @@ WHERE {
 
     OPTIONAL { ?agendaActivity ?aaP ?aaO }
     OPTIONAL { ?aaS ?aaP_ ?agendaActivity }
+
+    OPTIONAL { ?submissionActivity ?saP ?saO }
+    OPTIONAL { ?saS ?saP_ ?submissionActivity }
     ###
 
     ?agendaActivity besluitvor:genereertAgendapunt ?agendaitem .
     ?agendaitem ext:isGoedkeuringVanDeNotulen ?isApproval .
-
-    ###
-    # Update other agendaitems' positions
-    ?agenda dct:hasPart ?agendaitem .
-    ?agenda dct:hasPart ?otherAgendaitem .
-    ?otherAgendaitem dct:type <http://themis.vlaanderen.be/id/concept/agendapunt-type/dd47a8f8-3ad2-4d5a-8318-66fc02fe80fd> .
-    ?agendaitem schema:position ?agendaitemPosition .
-    ?otherAgendaitem schema:position ?otherAgendaitemPosition .
-    FILTER (?otherAgendaitemPosition < ?agendaitemPosition)
-    BIND(?otherAgendaitemPosition + 1 AS ?newOtherAgendaitemPosition)
-    ###
   }
 }

--- a/config/migrations/20230616102023-remove-wrong-cases.sparql
+++ b/config/migrations/20230616102023-remove-wrong-cases.sparql
@@ -1,0 +1,72 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX schema: <http://schema.org/>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX besluitvor: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    ?decisionmakingFlow ?dcmfP ?dcmfO .
+   	?dcmfS ?dcmfP_ ?decisionmakingFlow .
+
+    ?case ?cP ?cO .
+    ?cS ?cP_ ?case .
+
+    ?subcase ?scP ?scO .
+    ?scS ?scP_ ?subcase .
+
+    ?agendaActivity ?aaP ?aaO .
+    ?aaS ?aaP_ ?agendaActivity .
+
+    ?agendaitem schema:position ?agendaitemPosition .
+    ?agendaitem ext:isGoedkeuringVanDeNotulen ?isApproval .
+    ?otherAgendaitem schema:position ?otherAgendaitemPosition .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    ?agendaitem schema:position 1 .
+    ?agendaitem ext:isGoedkeuringVanDeNotulen "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
+    ?otherAgendaitem schema:position ?newOtherAgendaitemPosition .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    VALUES ?decisionmakingFlowId { "8D5686A8-411C-11ED-BB35-EE395168DCF7" "8C806F51-411C-11ED-BB35-EE395168DCF7" }
+    ?decisionmakingFlow mu:uuid ?decisionmakingFlowId .
+
+    ###
+    # Stuff we need to delete
+    ?case dossier:Dossier.isNeerslagVan ?decisionmakingFlow .
+    ?decisionmakingFlow dossier:doorloopt ?subcase .
+    ?agendaActivity besluitvor:vindtPlaatsTijdens ?subcase .
+
+    OPTIONAL { ?decisionmakingFlow ?dcmfP ?dcmfO }
+   	OPTIONAL { ?dcmfS ?dcmfP_ ?decisionmakingFlow }
+
+    OPTIONAL { ?case ?cP ?cO }
+    OPTIONAL { ?cS ?cP_ ?case }
+
+    OPTIONAL { ?subcase ?scP ?scO }
+    OPTIONAL { ?scS ?scP_ ?subcase }
+
+    OPTIONAL { ?agendaActivity ?aaP ?aaO }
+    OPTIONAL { ?aaS ?aaP_ ?agendaActivity }
+    ###
+
+    ?agendaActivity besluitvor:genereertAgendapunt ?agendaitem .
+    ?agendaitem ext:isGoedkeuringVanDeNotulen ?isApproval .
+
+    ###
+    # Update other agendaitems' positions
+    ?agenda dct:hasPart ?agendaitem .
+    ?agenda dct:hasPart ?otherAgendaitem .
+    ?otherAgendaitem dct:type <http://themis.vlaanderen.be/id/concept/agendapunt-type/dd47a8f8-3ad2-4d5a-8318-66fc02fe80fd> .
+    ?agendaitem schema:position ?agendaitemPosition .
+    ?otherAgendaitem schema:position ?otherAgendaitemPosition .
+    FILTER (?otherAgendaitemPosition < ?agendaitemPosition)
+    BIND(?otherAgendaitemPosition + 1 AS ?newOtherAgendaitemPosition)
+    ###
+  }
+}


### PR DESCRIPTION
- Removes the wrong cases, decisionmaking flows, subcases and agenda activities
- Resets the positions of the agendaitems (agendaitem for minutes was in position 5 and 7, they had to be set back to position 1 and all previous agendaitems had to be bumped)
- Sets the first agendaitem as agendaitem for minutes (`ext:isGoedkeuringVanDeNotulen` is true)

The two cases that needed fixing can be found here:
- https://kaleidos-test.vlaanderen.be/dossiers/8C806F51-411C-11ED-BB35-EE395168DCF7/deeldossiers/60A2B911364ED90008000080
- https://kaleidos-test.vlaanderen.be/dossiers/8D5686A8-411C-11ED-BB35-EE395168DCF7/deeldossiers/6294CF192071A7D754F17E9C

Migration was tested locally on a copy of an ACC database