### PR TITLE
Feature/kas 4143 bundled signing

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -278,7 +278,7 @@ defmodule Acl.UserGroups.Config do
     [
       %GroupSpec{
         name: "public",
-        useage: [:read],
+        useage: [:read, :read_for_write],
         access: %AlwaysAccessible{},
         graphs: [
           %GraphSpec{

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -492,6 +492,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/sign-completion-activities/"
   end
 
+  post "/signing-flows/upload-to-signinghub", @json_service do
+    Proxy.forward conn, [], "http://digital-signing/signing-flows/upload-to-signinghub"
+  end
+
   post "/signing-flows/:signing_flow_id/upload-to-signinghub", @json_service do
     Proxy.forward conn, [], "http://digital-signing/signing-flows/" <> signing_flow_id <> "/upload-to-signinghub"
   end

--- a/config/resources/handtekening-domain.json
+++ b/config/resources/handtekening-domain.json
@@ -174,7 +174,7 @@
           "cardinality": "one"
         },
         "sign-preparation-activity": {
-          "predicate": "prov:wasInformedBy",
+          "predicate": "sign:isGemarkeerdDoor",
           "target": "sign-preparation-activity",
           "cardinality": "one",
           "inverse": true
@@ -207,7 +207,7 @@
           "cardinality": "one"
         },
         "sign-marking-activity": {
-          "predicate": "prov:wasInformedBy",
+          "predicate": "sign:isGemarkeerdDoor",
           "target": "sign-marking-activity",
           "cardinality": "one"
         },


### PR DESCRIPTION
- Makes the public graph `:read_for_write`-able (not strictly necessary for this PR but we should've done this earlier as update queries where the public graph is queried won't work otherwise).
- Adds the new endpoint for the digital signing service.
- Updates the predicate linking a preparation activity and a marking activity, as `prov:wasInformedBy` is already in use and mu-cl-resources isn't able to re-use predicates. We didn't notice this issue earlier because we never linked the marking and preparation activities.