### PR TITLE
added position for signflow statuses for sorting purposes

### DIFF
--- a/config/migrations/20230627150000-add-signflow-status-codelist.graph
+++ b/config/migrations/20230627150000-add-signflow-status-codelist.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20230627150000-add-signflow-status-position.ttl
+++ b/config/migrations/20230627150000-add-signflow-status-position.ttl
@@ -1,0 +1,15 @@
+@prefix schema: <http://schema.org/> .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/f6a60072-0537-11ee-bb35-ee395168dcf7> schema:position 1 .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/1dd296c2-053a-11ee-bb35-ee395168dcf7> schema:position 2 .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/2fd72150-0538-11ee-bb35-ee395168dcf7> schema:position 3 .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/47508452-0538-11ee-bb35-ee395168dcf7> schema:position 4 .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/29d4e7d2-0539-11ee-bb35-ee395168dcf7> schema:position 5 .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/3128aae6-0539-11ee-bb35-ee395168dcf7> schema:position 6 .
+
+<http://themis.vlaanderen.be/id/handtekenstatus/2d043722-053a-11ee-bb35-ee395168dcf7> schema:position 7 .


### PR DESCRIPTION
To be used in filter components, etc. Anywhere we want to list these statuses, and want to enforce a logical order.