### PR TITLE
Fix/BS thread ID

### DIFF
--- a/config/resources/generiek-domain.json
+++ b/config/resources/generiek-domain.json
@@ -69,6 +69,12 @@
           "predicate": "pub:identifier",
           "cardinality": "one",
           "inverse": true
+        },
+        "publication-flow-for-thread-id": {
+          "target": "publication-flow",
+          "predicate": "pub:threadId",
+          "cardinality": "one",
+          "inverse": true
         }
       },
       "features": [

--- a/config/resources/publicatie-domain.json
+++ b/config/resources/publicatie-domain.json
@@ -104,6 +104,11 @@
           "target": "mandatee",
           "cardinality": "many"
         },
+        "thread-id": {
+          "predicate": "pub:threadId",
+          "target": "identification",
+          "cardinality": "one"
+        },
         "numac-numbers": {
           "predicate": "pub:identifier",
           "target": "identification",


### PR DESCRIPTION
Adds a new relation to publication flows, thread ID, where users can input the thread ID used by BS' case system.

:warning: Note: no migrations were added, contrary to the ticket statement, because users can manually edit the email in Kaleidos. An admin should navigate to `/instellingen/emailberichten`  and edit the address there.

JIRA: https://kanselarij.atlassian.net/browse/KAS-4168