### PR TITLE
Feature/kas 3842 additive search indices

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -354,10 +354,36 @@ defmodule Acl.UserGroups.Config do
         ]
       },
 
-      ### Secretarie
+      ### Secretarie & OVRB → "Intern secretarie" access level
+      ### All the secretarie & OVRB roles read the same data,
+      ### but OVRB can only write a limited amount
       %GroupSpec{
-        name: "secretarie",
-        useage: [:read, :write, :read_for_write],
+        name: "kanselarij-read",
+        useage: [:read, :read_for_write],
+        access: access_by_role(admin_roles() ++ secretarie_roles() ++ ovrb_roles() ++ kort_bestek_roles()),
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/organizations/kanselarij",
+            constraint: %ResourceConstraint{
+              resource_types: newsletter_resource_types() ++
+                agendering_resource_types() ++
+                generic_besluitvorming_resource_types() ++
+                document_resource_types() ++
+                file_bundling_resource_types() ++
+                publication_resource_types()
+            }
+          },
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/system/email",
+            constraint: %ResourceConstraint{
+              resource_types: email_resource_types()
+            }
+          }
+        ]
+      },
+      %GroupSpec{
+        name: "kanselarij-write",
+        useage: [:write, :read_for_write],
         access: access_by_role(admin_roles() ++ secretarie_roles() ++ kort_bestek_roles()),
         graphs: [
           %GraphSpec{
@@ -380,9 +406,8 @@ defmodule Acl.UserGroups.Config do
         ]
       },
       %GroupSpec{
-        name: "ovrb",
-        useage: [:read, :write, :read_for_write],
-        # TODO: Read access on whole "kanselarij"-graph for now.
+        name: "ovrb-write",
+        useage: [:write, :read_for_write],
         access: access_by_role(admin_roles() ++ ovrb_roles()),
         graphs: [
           %GraphSpec{

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -319,17 +319,13 @@ defmodule Acl.UserGroups.Config do
           }
         ]
       },
+
+      ### System-specific data access for admin users
       %GroupSpec{
         name: "admin",
         useage: [:read, :write, :read_for_write],
-        access: access_by_own_role(admin_roles()),
+        access: access_by_role(admin_roles()),
         graphs: [
-          %GraphSpec{
-            graph: "http://mu.semte.ch/graphs/sessions",
-            constraint: %ResourceFormatConstraint{
-              resource_prefix: "http://mu.semte.ch/sessions/"
-            }
-          },
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/system/users",
             constraint: %ResourceConstraint{
@@ -344,6 +340,21 @@ defmodule Acl.UserGroups.Config do
           }
         ]
       },
+      %GroupSpec{
+        name: "impersonation",
+        useage: [:read, :write, :read_for_write],
+        access: access_by_own_role(admin_roles()),
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/sessions",
+            constraint: %ResourceFormatConstraint{
+              resource_prefix: "http://mu.semte.ch/sessions/"
+            }
+          }
+        ]
+      },
+
+      ### Secretarie
       %GroupSpec{
         name: "secretarie",
         useage: [:read, :write, :read_for_write],
@@ -390,9 +401,32 @@ defmodule Acl.UserGroups.Config do
           }
         ]
       },
+
+      ### Ministers & their cabinet chiefs → "Vetrouwelijk" access level
       %GroupSpec{
-        name: "o-minister-read",
-        useage: [:read, :write, :read_for_write],
+        name: "minister-read",
+        useage: [:read, :read_for_write],
+        access: access_by_role(
+          minister_roles()
+          ++ kabinet_dossierbeheerder_roles() # Technically this spec is too broad for dossierbeheerders, but we add extra checks down the line
+        ),
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/organizations/minister",
+            constraint: %ResourceConstraint{
+              resource_types: newsletter_resource_types() ++
+                agendering_resource_types() ++
+                generic_besluitvorming_resource_types() ++
+                document_resource_types() ++
+                file_bundling_resource_types() ++
+                publication_resource_types()
+            }
+          }
+        ]
+      },
+      %GroupSpec{
+        name: "minister-write",
+        useage: [:write, :read_for_write],
         access: access_by_role(
           minister_roles()
           ++ kabinet_dossierbeheerder_roles() # Technically this spec is too broad for dossierbeheerders, but we add extra checks down the line
@@ -406,9 +440,29 @@ defmodule Acl.UserGroups.Config do
           }
         ]
       },
+
+      ### Cabinet staff
       %GroupSpec{
-        name: "o-intern-regering-read",
-        useage: [:read, :write, :read_for_write],
+        name: "regering-read",
+        useage: [:read, :read_for_write],
+        access: access_by_role(kabinet_medewerker_roles()),
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/organizations/intern-regering",
+            constraint: %ResourceConstraint{
+              resource_types: newsletter_resource_types() ++
+                agendering_resource_types() ++
+                generic_besluitvorming_resource_types() ++
+                document_resource_types() ++
+                file_bundling_resource_types() ++
+                publication_resource_types()
+            }
+          }
+        ]
+      },
+      %GroupSpec{
+        name: "regering-write",
+        useage: [:write, :read_for_write],
         access: access_by_role(kabinet_medewerker_roles()),
         graphs: [
           %GraphSpec{
@@ -419,9 +473,29 @@ defmodule Acl.UserGroups.Config do
           }
         ]
       },
+
+      ### Government staff
       %GroupSpec{
-        name: "o-intern-overheid-read",
-        useage: [:read, :write, :read_for_write],
+        name: "overheid-read",
+        useage: [:read, :read_for_write],
+        access: access_by_role(overheid_roles()),
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/organizations/intern-overheid",
+            constraint: %ResourceConstraint{
+              resource_types: newsletter_resource_types() ++
+                agendering_resource_types() ++
+                generic_besluitvorming_resource_types() ++
+                document_resource_types() ++
+                file_bundling_resource_types() ++
+                publication_resource_types()
+            }
+          }
+        ]
+      },
+      %GroupSpec{
+        name: "overheid-write",
+        useage: [:write, :read_for_write],
         access: access_by_role(overheid_roles()),
         graphs: [
           %GraphSpec{
@@ -432,6 +506,8 @@ defmodule Acl.UserGroups.Config do
           }
         ]
       },
+
+      ### Sign flow metadata
       %GroupSpec{
         name: "sign-flow-read",
         useage: [:read],

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -6,6 +6,7 @@
   "automatic_index_updates": true,
   "eager_indexing_groups": [
     [ { "name": "clean", "variables": [] } ],
+    [ { "name": "public", "variables": [] } ],
     [ { "name": "admin", "variables": [] } ],
     [ { "name": "impersonation", "variables": [] } ],
     [ { "name": "authenticated", "variables": [] } ],

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -5,56 +5,38 @@
   "update_wait_interval_minutes": 0,
   "automatic_index_updates": true,
   "eager_indexing_groups": [
+    [ { "name": "clean", "variables": [] } ],
+    [ { "name": "admin", "variables": [] } ],
+    [ { "name": "impersonation", "variables": [] } ],
+    [ { "name": "authenticated", "variables": [] } ],
+    [ { "name": "minister-write", "variables": [] } ],
+    [ { "name": "regering-write", "variables": [] } ],
+    [ { "name": "overheid-write", "variables": [] } ],
+    [ { "name": "sign-flow-read", "variables": [] } ],
+    [ { "name": "sign-flow-write", "variables": [] } ],
+
     [
-      { "name": "admin", "variables": [] },
       { "name": "secretarie", "variables": [] },
-      { "name": "ovrb", "variables": [] },
-      { "name": "sign-flow-read", "variables": [] },
-      { "name": "sign-flow-write", "variables": [] },
-      { "name": "authenticated", "variables": [] },
-      { "name": "public", "variables": [] },
-      { "name": "clean", "variables": [] }
-    ],
-    [
-      { "name": "secretarie", "variables": [] },
-      { "name": "sign-flow-read", "variables": [] },
-      { "name": "sign-flow-write", "variables": [] },
-      { "name": "authenticated", "variables": [] },
-      { "name": "public", "variables": [] },
-      { "name": "clean", "variables": [] }
+      { "name": "public", "variables": [] }
     ],
     [
       { "name": "ovrb", "variables": [] },
-      { "name": "authenticated", "variables": [] },
-      { "name": "sign-flow-read", "variables": [] },
-      { "name": "public", "variables": [] },
-      { "name": "clean", "variables": [] }
+      { "name": "public", "variables": [] }
     ],
     [
-      { "name": "o-minister-read", "variables": [] },
-      { "name": "sign-flow-write", "variables": [] },
-      { "name": "sign-flow-read", "variables": [] },
-      { "name": "authenticated", "variables": [] },
-      { "name": "public", "variables": [] },
-      { "name": "clean", "variables": [] }
+      { "name": "minister-read", "variables": [] },
+      { "name": "public", "variables": [] }
     ],
     [
-      { "name": "o-intern-regering-read", "variables": [] },
-      { "name": "sign-flow-read", "variables": [] },
-      { "name": "authenticated", "variables": [] },
-      { "name": "public", "variables": [] },
-      { "name": "clean", "variables": [] }
+      { "name": "regering-read", "variables": [] },
+      { "name": "public", "variables": [] }
     ],
     [
-      { "name": "o-intern-overheid-read", "variables": [] },
-      { "name": "authenticated", "variables": [] },
-      { "name": "public", "variables": [] },
-      { "name": "clean", "variables": [] }
+      { "name": "overheid-read", "variables": [] },
+      { "name": "public", "variables": [] }
     ]
   ],
   "attachments_path_base": "/data/",
-  "eager_indexing_sparql_query": false,
-  "additive_indexes": false,
   "persist_indexes": true,
   "default_settings": {
     "analysis": {

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -10,6 +10,8 @@
     [ { "name": "admin", "variables": [] } ],
     [ { "name": "impersonation", "variables": [] } ],
     [ { "name": "authenticated", "variables": [] } ],
+    [ { "name": "kanselarij-write", "variables": [] } ],
+    [ { "name": "ovrb-write", "variables": [] } ],
     [ { "name": "minister-write", "variables": [] } ],
     [ { "name": "regering-write", "variables": [] } ],
     [ { "name": "overheid-write", "variables": [] } ],
@@ -17,11 +19,7 @@
     [ { "name": "sign-flow-write", "variables": [] } ],
 
     [
-      { "name": "secretarie", "variables": [] },
-      { "name": "public", "variables": [] }
-    ],
-    [
-      { "name": "ovrb", "variables": [] },
+      { "name": "kanselarij-read", "variables": [] },
       { "name": "public", "variables": [] }
     ],
     [

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,6 +8,8 @@ services:
       - ./testdata/files:/data
     environment:
       UPDATE_WAIT_INTERVAL_MINUTES: 0
+      LOG_SCOPE_AUTHORIZATION: "debug"
+      LOG_SCOPE_SEARCH: "debug"
   elasticsearch:
     volumes:
       - ./testdata/elasticsearch/:/usr/share/elasticsearch/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -387,7 +387,7 @@ services:
     volumes:
       - ./data/files:/share
   digital-signing:
-    image: kanselarij/digital-signing-service:1.1.0
+    image: kanselarij/digital-signing-service:1.2.0
     volumes:
       - ./data/files:/share
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     labels:
       - "logging=true"
   search:
-    image: semtech/mu-search:0.9.0-beta.3
+    image: semtech/mu-search:0.9.0-beta.7
     volumes:
       - ./config/search:/config
       - ./data/files:/data


### PR DESCRIPTION
Uses mu-search `0.9.0-beta.7` and applies the necessary config changes to use the new additive indices.
PR setup for tracking and to trigger tests on Jenkins, accompanied by an empty frontend PR.

Requires:
- [x] https://github.com/kanselarij-vlaanderen/cache-warmup-service/pull/13

Frontend PR can be closed, it's empty.