### PR TITLE
fix: set timezone of decision report generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -362,6 +362,8 @@ services:
       - "logging=true"
   decision-report-generation:
     image: kanselarij/decision-report-generation-service:0.1.0
+    environment:
+      TZ: "Europe/Brussels"
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
Since we now use dates in this service (to render the date of the meeting), we need to take the timezone into account, otherwise we might run into off by one dates when the time is set to midnight (probably only happens in test data, but it's best to be safe).