### PR TITLE
Feature/KAS-4271: digital-signing health check

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -504,6 +504,10 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://digital-signing/signing-flows/" <> signing_flow_id <> "/pieces/" <> piece_id <> "/signinghub-url"
   end
 
+  get "/digital-signing/health-check", @json_service do
+    Proxy.forward conn, [], "http://digital-signing/verify-credentials"
+  end
+
   get "/mail-folders/*path", @json_service do
     Proxy.forward conn, path, "http://cache/mail-folders/"
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -389,7 +389,7 @@ services:
     volumes:
       - ./data/files:/share
   digital-signing:
-    image: kanselarij/digital-signing-service:feature-KAS-4271-digital-signing-health-check
+    image: kanselarij/digital-signing-service:1.7.3
     volumes:
       - ./data/files:/share
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -387,7 +387,7 @@ services:
     volumes:
       - ./data/files:/share
   digital-signing:
-    image: kanselarij/digital-signing-service:1.5.0
+    image: kanselarij/digital-signing-service:feature-KAS-4271-digital-signing-health-check
     volumes:
       - ./data/files:/share
     restart: always


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4271

Exposes the digital-signing-service `/verify-credentials` as a `health-check` endpoint that can be added to Prometheus.

The health-check behaviour can be checked by hitting `/digital-signing/health-check` on DEV or ACC and verifying that we receive 204 responses when OK and 500 when not okay. Turning off the digital-signing service or breaking the `config/digital-signing/authentication.py` file should cause the service to return a 500.

~~Note: the actual addition to Prometheus hasn't happened yet, I'll leave this PR in draft until it's the case.~~ Ask Niels to add the endpoint to Prometheus after it's been deployed

**Suggested testing steps**:
- `curl` the endpoint (http://localhost:4200/digital-signing/health-check) and check for a `204 NO CONTENT` response (curl recommended because the endpoint has to work without a session)
- Change `authentication_config.py` and set wrong credentials, check that the endpoint now returns a 500
- Turn off the service and check that the endpoint also returns a 500