### PR TITLE
Feature/kas 4322 pub search for all

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -667,6 +667,7 @@
       "properties": {
         "title": "http://purl.org/dc/terms/title",
         "shortTitle": "http://purl.org/dc/terms/alternative",
+        "modified": "http://purl.org/dc/terms/modified",
         "remark": "https://www.w3.org/2000/01/rdf-schema#comment",
         "identification": [
           "http://www.w3.org/ns/adms#identifier",
@@ -683,6 +684,15 @@
         "caseId": [
           "https://data.vlaanderen.be/ns/dossier#behandelt",
           "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
+        "decisionmakingFlowId": [
+          "https://data.vlaanderen.be/ns/dossier#behandelt",
+          "https://data.vlaanderen.be/ns/dossier#Dossier.isNeerslagVan",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
+        "status": [
+          "http://www.w3.org/ns/adms#status",
+          "http://www.w3.org/2004/02/skos/core#prefLabel"
         ],
         "statusId": [
           "http://www.w3.org/ns/adms#status",
@@ -720,6 +730,14 @@
         "decisionDate": [
           "http://purl.org/dc/terms/subject",
           "https://data.vlaanderen.be/ns/dossier#Activiteit.startdatum"
+        ],
+        "sessionDate": [
+          "http://purl.org/dc/terms/subject",
+          "^https://data.vlaanderen.be/ns/besluitvorming#heeftBeslissing",
+          "http://purl.org/dc/terms/subject",
+          "^http://purl.org/dc/terms/hasPart",
+          "https://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
+          "http://data.vlaanderen.be/ns/besluit#geplandeStart"
         ],
         "openingDate": "https://data.vlaanderen.be/ns/dossier#openingsdatum",
         "translationRequestDate": [
@@ -762,6 +780,9 @@
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"
           },
+          "modified": {
+            "type": "date"
+          },
           "remark": {
             "type": "text",
             "analyzer": "dutchanalyzer",
@@ -778,6 +799,14 @@
           },
           "caseId": {
             "type": "keyword"
+          },
+          "decisionmakingFlowId": {
+            "type": "keyword"
+          },
+          "status": {
+            "type": "text",
+            "analyzer": "dutchanalyzer",
+            "search_analyzer": "dutchanalyzer"
           },
           "statusId": {
             "type": "keyword"
@@ -805,6 +834,9 @@
             "type": "date"
           },
           "decisionDate": {
+            "type": "date"
+          },
+          "sessionDate": {
             "type": "date"
           },
           "openingDate": {

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -798,16 +798,12 @@
           "http://xmlns.com/foaf/0.1/familyName"
         ],
         "tempGovernmentAreaIds": [
-          "http://purl.org/dc/terms/subject",
-          "http://mu.semte.ch/vocabularies/ext/beslissingVindtPlaatsTijdens",
-          "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+          "http://mu.semte.ch/vocabularies/ext/publicatie/beleidsveld",
           "http://www.w3.org/2004/02/skos/core#broader",
           "http://mu.semte.ch/vocabularies/core/uuid"
         ],
         "tempGovernmentFieldIds": [
-          "http://purl.org/dc/terms/subject",
-          "http://mu.semte.ch/vocabularies/ext/beslissingVindtPlaatsTijdens",
-          "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+          "http://mu.semte.ch/vocabularies/ext/publicatie/beleidsveld",
           "http://mu.semte.ch/vocabularies/core/uuid"
         ],
         "regulationTypeId": [

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -105,15 +105,15 @@
           "http://purl.org/dc/terms/alternative"
         ],     
         "tempGovernmentAreaIds": [
-          "^http://www.w3.org/ns/prov#generated",
-          "http://mu.semte.ch/vocabularies/ext/indieningVindtPlaatsTijdens",
+          "^https://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt",
+          "https://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens",
           "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
           "http://www.w3.org/2004/02/skos/core#broader",
           "http://mu.semte.ch/vocabularies/core/uuid"
         ],
         "tempGovernmentFieldIds": [
-          "^http://www.w3.org/ns/prov#generated",
-          "http://mu.semte.ch/vocabularies/ext/indieningVindtPlaatsTijdens",
+          "^https://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt",
+          "https://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens",
           "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
           "http://mu.semte.ch/vocabularies/core/uuid"
         ],

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -269,10 +269,10 @@
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"
           },
-          "governmentAreaIds": {
+          "tempGovernmentAreaIds": {
             "type": "keyword"
           },
-          "governmentFieldIds": {
+          "tempGovernmentFieldIds": {
             "type": "keyword"
           },
           "mandateRoles": {
@@ -548,13 +548,13 @@
           "https://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
           "http://data.vlaanderen.be/ns/besluit#geplandeStart"
         ],
-        "governmentAreaIds": [
+        "tempGovernmentAreaIds": [
           "https://data.vlaanderen.be/ns/dossier#doorloopt",
           "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
           "http://www.w3.org/2004/02/skos/core#broader",
           "http://mu.semte.ch/vocabularies/core/uuid"
         ],
-        "governmentFieldIds": [
+        "tempGovernmentFieldIds": [
           "https://data.vlaanderen.be/ns/dossier#doorloopt",
           "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
           "http://mu.semte.ch/vocabularies/core/uuid"
@@ -676,10 +676,10 @@
           "sessionDates": {
             "type": "date"
           },
-          "governmentAreaIds": {
+          "tempGovernmentAreaIds": {
             "type": "keyword"
           },
-          "governmentFieldIds": {
+          "tempGovernmentFieldIds": {
             "type": "keyword"
           },
           "subcaseTitle": {
@@ -797,6 +797,19 @@
           "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
           "http://xmlns.com/foaf/0.1/familyName"
         ],
+        "tempGovernmentAreaIds": [
+          "http://purl.org/dc/terms/subject",
+          "http://mu.semte.ch/vocabularies/ext/beslissingVindtPlaatsTijdens",
+          "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+          "http://www.w3.org/2004/02/skos/core#broader",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
+        "tempGovernmentFieldIds": [
+          "http://purl.org/dc/terms/subject",
+          "http://mu.semte.ch/vocabularies/ext/beslissingVindtPlaatsTijdens",
+          "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
         "regulationTypeId": [
           "http://mu.semte.ch/vocabularies/ext/publicatie/regelgevingType",
           "http://mu.semte.ch/vocabularies/core/uuid"
@@ -849,6 +862,14 @@
         ]
       },
       "mappings": {
+        "runtime": {
+          "governmentAreaIds": {
+            "type": "keyword",
+            "script": {
+              "source": "if (doc['tempGovernmentAreaIds'].size() > 0) { emit(doc['tempGovernmentAreaIds'].value) } else if (doc['tempGovernmentFieldIds'].size() > 0) { emit(doc['tempGovernmentFieldIds'].value) } else { emit ('') }"
+            }
+          }
+        },
         "properties": {
           "title": {
             "type": "text",
@@ -906,6 +927,12 @@
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"
+          },
+          "tempGovernmentAreaIds": {
+            "type": "keyword"
+          },
+          "tempGovernmentFieldIds": {
+            "type": "keyword"
           },
           "regulationTypeId": {
             "type": "keyword"
@@ -994,14 +1021,14 @@
               "https://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
               "http://mu.semte.ch/vocabularies/core/uuid"
             ],
-            "governmentAreaIds": [
+            "tempGovernmentAreaIds": [
               "^https://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt",
               "https://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens",
               "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
               "http://www.w3.org/2004/02/skos/core#broader",
               "http://mu.semte.ch/vocabularies/core/uuid"
             ],
-            "governmentFieldIds": [
+            "tempGovernmentFieldIds": [
               "^https://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt",
               "https://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens",
               "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
@@ -1083,10 +1110,10 @@
           "agendaitems.meetingId": {
             "type": "keyword"
           },
-          "agendaitems.governmentAreaIds": {
+          "agendaitems.tempGovernmentAreaIds": {
             "type": "keyword"
           },
-          "agendaitems.governmentFieldIds": {
+          "agendaitems.tempGovernmentFieldIds": {
             "type": "keyword"
           },
           "agendaitems.mandatees.priority": {

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -102,6 +102,19 @@
           "^https://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt",
           "https://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens",
           "http://purl.org/dc/terms/alternative"
+        ],     
+        "tempGovernmentAreaIds": [
+          "^http://www.w3.org/ns/prov#generated",
+          "http://mu.semte.ch/vocabularies/ext/indieningVindtPlaatsTijdens",
+          "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+          "http://www.w3.org/2004/02/skos/core#broader",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
+        "tempGovernmentFieldIds": [
+          "^http://www.w3.org/ns/prov#generated",
+          "http://mu.semte.ch/vocabularies/ext/indieningVindtPlaatsTijdens",
+          "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+          "http://mu.semte.ch/vocabularies/core/uuid"
         ],
         "mandateRoles": [
           "http://mu.semte.ch/vocabularies/ext/heeftBevoegdeVoorAgendapunt",
@@ -206,6 +219,14 @@
         }
       },
       "mappings": {
+        "runtime": {
+          "governmentAreaIds": {
+            "type": "keyword",
+            "script": {
+              "source": "if (doc['tempGovernmentAreaIds'].size() > 0) { emit(doc['tempGovernmentAreaIds'].value) } else if (doc['tempGovernmentFieldIds'].size() > 0) { emit(doc['tempGovernmentFieldIds'].value) } else { emit ('') }"
+            }
+          }
+        },
         "properties": {
           "title": {
             "type": "text",
@@ -247,6 +268,12 @@
             "type": "text",
             "analyzer": "dutchanalyzer",
             "search_analyzer": "dutchanalyzer"
+          },
+          "governmentAreaIds": {
+            "type": "keyword"
+          },
+          "governmentFieldIds": {
+            "type": "keyword"
           },
           "mandateRoles": {
             "type": "text",
@@ -349,6 +376,19 @@
           "^http://purl.org/pav/previousVersion",
           "http://mu.semte.ch/vocabularies/core/uuid"
         ],
+        "tempGovernmentAreaIds": [
+          "^http://www.w3.org/ns/prov#generated",
+          "http://mu.semte.ch/vocabularies/ext/indieningVindtPlaatsTijdens",
+          "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+          "http://www.w3.org/2004/02/skos/core#broader",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
+        "tempGovernmentFieldIds": [
+          "^http://www.w3.org/ns/prov#generated",
+          "http://mu.semte.ch/vocabularies/ext/indieningVindtPlaatsTijdens",
+          "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
         "mandateeIds": [
           "^https://data.vlaanderen.be/ns/dossier#Dossier.bestaatUit",
           "https://data.vlaanderen.be/ns/dossier#Dossier.isNeerslagVan",
@@ -392,6 +432,14 @@
         }
       },
       "mappings": {
+        "runtime": {
+          "governmentAreaIds": {
+            "type": "keyword",
+            "script": {
+              "source": "if (doc['tempGovernmentAreaIds'].size() > 0) { emit(doc['tempGovernmentAreaIds'].value) } else if (doc['tempGovernmentFieldIds'].size() > 0) { emit(doc['tempGovernmentFieldIds'].value) } else { emit ('') }"
+            }
+          }
+        },
         "properties": {
           "title": {
             "type": "text",
@@ -411,6 +459,12 @@
             "type": "keyword"
           },
           "nextPieceId": {
+            "type": "keyword"
+          },
+          "tempGovernmentAreaIds": {
+            "type": "keyword"
+          },
+          "tempGovernmentFieldIds": {
             "type": "keyword"
           },
           "mandateeIds": {
@@ -494,6 +548,17 @@
           "https://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
           "http://data.vlaanderen.be/ns/besluit#geplandeStart"
         ],
+        "governmentAreaIds": [
+          "https://data.vlaanderen.be/ns/dossier#doorloopt",
+          "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+          "http://www.w3.org/2004/02/skos/core#broader",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
+        "governmentFieldIds": [
+          "https://data.vlaanderen.be/ns/dossier#doorloopt",
+          "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
         "subcaseTitle": [
           "https://data.vlaanderen.be/ns/dossier#doorloopt",
           "http://purl.org/dc/terms/title"
@@ -565,6 +630,14 @@
         ]
       },
       "mappings": {
+        "runtime": {
+          "governmentAreaIds": {
+            "type": "keyword",
+            "script": {
+              "source": "if (doc['tempGovernmentAreaIds'].size() > 0) { emit(doc['tempGovernmentAreaIds'].value) } else if (doc['tempGovernmentFieldIds'].size() > 0) { emit(doc['tempGovernmentFieldIds'].value) } else { emit ('') }"
+            }
+          }
+        },
         "properties": {
           "closedDate": {
             "type": "date"
@@ -602,6 +675,12 @@
           },
           "sessionDates": {
             "type": "date"
+          },
+          "governmentAreaIds": {
+            "type": "keyword"
+          },
+          "governmentFieldIds": {
+            "type": "keyword"
           },
           "subcaseTitle": {
             "type": "text",
@@ -883,6 +962,19 @@
               "https://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor",
               "http://mu.semte.ch/vocabularies/core/uuid"
             ],
+            "governmentAreaIds": [
+              "^https://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt",
+              "https://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens",
+              "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+              "http://www.w3.org/2004/02/skos/core#broader",
+              "http://mu.semte.ch/vocabularies/core/uuid"
+            ],
+            "governmentFieldIds": [
+              "^https://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt",
+              "https://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens",
+              "https://data.vlaanderen.be/ns/besluitvorming#beleidsveld",
+              "http://mu.semte.ch/vocabularies/core/uuid"
+            ],
             "mandatees": {
               "via": [
                 "http://mu.semte.ch/vocabularies/ext/heeftBevoegdeVoorAgendapunt"
@@ -908,6 +1000,14 @@
         }
       },
       "mappings": {
+        "runtime": {
+          "governmentAreaIds": {
+            "type": "keyword",
+            "script": {
+              "source": "if (doc['agendaitems.tempGovernmentAreaIds'].size() > 0) { emit(doc['agendaitems.tempGovernmentAreaIds'].value) } else if (doc['agendaitems.tempGovernmentFieldIds'].size() > 0) { emit(doc['agendaitems.tempGovernmentFieldIds'].value) } else { emit ('') }"
+            }
+          }
+        },
         "properties": {
           "title": {
             "type": "text",
@@ -949,6 +1049,12 @@
             "type": "date"
           },
           "agendaitems.meetingId": {
+            "type": "keyword"
+          },
+          "agendaitems.governmentAreaIds": {
+            "type": "keyword"
+          },
+          "agendaitems.governmentFieldIds": {
             "type": "keyword"
           },
           "agendaitems.mandatees.priority": {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4322

Added following attributes to publication flow index:
- modified
- decisionmakingFlowId
- status (the label, so we can show it in the frontend's result card)
- sessionDate (via the decision-activity → agendaitem)

These are needed to implement the generic publication flow search route for all profile.