### PR TITLE
Feature/kas 4379 bundle BFs and minutes

### DIFF
--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -189,6 +189,9 @@
                                         :as "agendas")
               (piece                    :via      ,(s-prefix "ext:zittingDocumentversie")
                                         :as "pieces")
+              (sign-flow                :via      ,(s-prefix "sign:heeftVergadering")
+                                        :inverse t
+                                        :as "sign-flows")
               (themis-publication-activity :via   ,(s-prefix "prov:used")
                                            :inverse t
                                            :as "themis-publication-activities"))

--- a/config/resources/document-domain.lisp
+++ b/config/resources/document-domain.lisp
@@ -13,7 +13,6 @@
 (define-resource piece ()
   :class (s-prefix "dossier:Stuk")
   :properties `((:name                  :string   ,(s-prefix "dct:title"))
-                (:is-report-or-minutes  :boolean   ,(s-prefix "ext:isReportOrMinutes")) ;; this property is necessary until we can filter on subclass
                 (:created               :datetime ,(s-prefix "dct:created"))
                 (:modified              :datetime ,(s-prefix "dct:modified"))
                 (:received-date         :datetime ,(s-prefix "fabio:hasDateReceived"))

--- a/config/resources/handtekening-domain.json
+++ b/config/resources/handtekening-domain.json
@@ -62,6 +62,11 @@
           "target": "decision-activity",
           "cardinality": "one"
         },
+        "meeting": {
+          "predicate": "sign:heeftVergadering",
+          "target": "meeting",
+          "cardinality": "one"
+        },
         "creator": {
           "predicate": "dct:creator",
           "target": "user",


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4379

Removes the `is-report-or-minutes` attribute from piece and adds a link between sign-flow and meeting.