### PR TITLE
Feature/kas 4433 send to vp role permissions

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -592,8 +592,31 @@ defmodule Acl.UserGroups.Config do
       },
 
       %GroupSpec{
-        name: "parliament-flow",
-        useage: [:read, :write, :read_for_write],
+        name: "parliament-flow-read",
+        useage: [:read],
+        access: access_by_role(
+          admin_roles()
+          ++ secretarie_roles()
+          ++ ovrb_roles()
+          ++ kort_bestek_roles()
+          ++ minister_roles()
+          ++ kabinet_dossierbeheerder_roles()
+          ++ kabinet_medewerker_roles()
+          ++ overheid_roles()
+        ),
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/system/parliament",
+            constraint: %ResourceConstraint{
+              resource_types: parliament_resource_types()
+            }
+          }
+        ]
+      },
+
+      %GroupSpec{
+        name: "parliament-flow-write",
+        useage: [:write, :read_for_write],
         access: access_by_role(
           admin_roles()
           ++ secretarie_roles()

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -576,6 +576,8 @@ defmodule Acl.UserGroups.Config do
         useage: [:write, :read_for_write],
         access: access_by_role(
           admin_roles()
+          ++ secretarie_roles()
+          ++ kort_bestek_roles()
           ++ minister_roles()
           ++ kabinet_dossierbeheerder_roles()
         ),

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -619,8 +619,6 @@ defmodule Acl.UserGroups.Config do
         useage: [:write, :read_for_write],
         access: access_by_role(
           admin_roles()
-          ++ secretarie_roles()
-          ++ kort_bestek_roles()
           ++ minister_roles()
           ++ kabinet_dossierbeheerder_roles()
         ),

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -576,8 +576,6 @@ defmodule Acl.UserGroups.Config do
         useage: [:write, :read_for_write],
         access: access_by_role(
           admin_roles()
-          ++ secretarie_roles()
-          ++ kort_bestek_roles()
           ++ minister_roles()
           ++ kabinet_dossierbeheerder_roles()
         ),

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -17,6 +17,8 @@
     [ { "name": "overheid-write", "variables": [] } ],
     [ { "name": "sign-flow-read", "variables": [] } ],
     [ { "name": "sign-flow-write", "variables": [] } ],
+    [ { "name": "parliament-flow-read", "variables": [] } ],
+    [ { "name": "parliament-flow-write", "variables": [] } ],
 
     [
       { "name": "kanselarij-read", "variables": [] },


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4433

Splits up `parliament-flow` groupspec into two, one for reading one for writing. Only admin, secretarie, kanselarij, kort-bestek, minister & kabinetdossierbeheerder can write.