### PR TITLE
Feature/KAS-4424: Use job approach for uploading sign flows to SigningHub

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -150,6 +150,12 @@ defmodule Acl.UserGroups.Config do
     ]
   end
 
+  defp prepare_sign_flow_job_types() do
+    [
+      "http://mu.semte.ch/vocabularies/ext/PrepareSignFlowJob",
+    ]
+  end
+
   defp publication_resource_types() do
     [
       "http://mu.semte.ch/vocabularies/ext/publicatie/Publicatieaangelegenheid",
@@ -577,6 +583,7 @@ defmodule Acl.UserGroups.Config do
             graph: "http://mu.semte.ch/graphs/system/signing",
             constraint: %ResourceConstraint{
               resource_types: sign_resource_types()
+              ++ prepare_sign_flow_job_types()
             }
           }
         ]

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -516,6 +516,10 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://digital-signing/signing-flows/mark-pieces-for-signing"
   end
 
+  get "/signing-flows/job/:id", @json_service do
+    Proxy.forward conn, [], "http://digital-signing/job/" <> id
+  end
+
   get "/mail-folders/*path", @json_service do
     Proxy.forward conn, path, "http://cache/mail-folders/"
   end


### PR DESCRIPTION
> [!WARNING]
> This PR is branched from https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/422 as cleaning up the sign flows in the backend fits better into a job approach

https://kanselarij.atlassian.net/browse/KAS-4424

Lets sign-flow writers create `ext:PrepareSignFlowJob`s so that the digital signing service will work for them.