### PR TITLE
KAS-4466 enable sending all subcase types

### DIFF
--- a/config/resources/parliament-domain.json
+++ b/config/resources/parliament-domain.json
@@ -112,6 +112,18 @@
       "name": "submitted-piece",
       "class": "parl:IngediendStuk",
       "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "dct:title"
+        },
+        "subcase-name": {
+          "type": "string",
+          "predicate": "parl:procedurestapNaam"
+        },
+        "subcase-created": {
+          "type": "datetime",
+          "predicate": "parl:procedurestapAangemaaktOp"
+        },
         "unsigned-file": {
           "type": "uri",
           "predicate": "parl:ongetekendBestand"


### PR DESCRIPTION
More information is stored about submitted pieces, so the loading time in the frontend decreases significantly.

Related PRs:
https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1993
https://github.com/kanselarij-vlaanderen/vlaams-parlement-sync-service/pull/8