### PR TITLE
KAS-4574: Add bekrachtiging file type

### DIFF
--- a/config/migrations/20240314131928-add-bekrachtiging-document-type.sparql
+++ b/config/migrations/20240314131928-add-bekrachtiging-document-type.sparql
@@ -1,0 +1,59 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX schema: <http://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?documentType schema:position ?oldPosition .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?documentType schema:position ?newPosition .
+
+    <http://themis.vlaanderen.be/id/concept/document-type/609cf883-b52c-43fe-84b1-eed02527173b> a skos:Concept, ext:DocumentType ;
+      mu:uuid "609cf883-b52c-43fe-84b1-eed02527173b" ;
+      skos:prefLabel "Bekrachtiging" ;
+      skos:altLabel "Bekrachtiging" ;
+      schema:position 14 ;
+      skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/559774e3-061c-4f4b-a758-57228d4b68cd> .
+  }
+}
+WHERE {
+  VALUES (?documentType ?oldPosition ?newPosition) {
+    (<http://themis.vlaanderen.be/id/concept/document-type/fbd697b7-9857-477f-8725-d6856a563f7a> 14 15)
+    (<http://themis.vlaanderen.be/id/concept/document-type/53aea93f-c0f7-4a9e-a5b3-5d683ccf783c> 15 16)
+    (<http://themis.vlaanderen.be/id/concept/document-type/e87f3a3a-d4dd-4560-8834-024b1e27a374> 16 17)
+    (<http://themis.vlaanderen.be/id/concept/document-type/63d628cb-a594-4166-8b4e-880b4214fc5b> 17 18)
+    (<http://themis.vlaanderen.be/id/concept/document-type/e807feec-1958-46cf-a558-3379b5add49e> 18 19)
+    (<http://themis.vlaanderen.be/id/concept/document-type/5c8689fc-af45-480e-b16a-ec1e61680acd> 19 20)
+    (<http://themis.vlaanderen.be/id/concept/document-type/8864821b-0eb8-42c6-99db-e39f20e9de10> 20 21)
+    (<http://themis.vlaanderen.be/id/concept/document-type/83888ef0-a44a-4abf-a977-acfcfa63ed8b> 21 22)
+    (<http://themis.vlaanderen.be/id/concept/document-type/eb048853-dc2e-44f8-9bf1-f0b7a7460a4d> 22 23)
+    (<http://themis.vlaanderen.be/id/concept/document-type/bcbd33f1-f058-46d0-9c53-569edd5dbede> 23 24)
+    (<http://themis.vlaanderen.be/id/concept/document-type/25b58316-50f2-411c-9012-e4e1957b1750> 24 25)
+    (<http://themis.vlaanderen.be/id/concept/document-type/1e254f84-d442-425e-9fc9-5ac552b9d089> 25 26)
+    (<http://themis.vlaanderen.be/id/concept/document-type/a270ebff-2883-4c96-95c7-64fa89a729c5> 26 27)
+    (<http://themis.vlaanderen.be/id/concept/document-type/7ef77ae1-816b-4eba-bae8-1f7d73cd7cba> 27 28)
+    (<http://themis.vlaanderen.be/id/concept/document-type/a354eebe-43d2-43b9-a018-483b3cd605ea> 28 29)
+    (<http://themis.vlaanderen.be/id/concept/document-type/126f7ca5-c1e8-458a-80c2-38828a6010cc> 29 30)
+    (<http://themis.vlaanderen.be/id/concept/document-type/72dd647f-7afa-4d2a-9c7f-de73a8bd85a1> 30 31)
+    (<https://data.vlaanderen.be/id/concept/AardWetgeving/MinisterieelBesluit> 31 32)
+    (<http://themis.vlaanderen.be/id/concept/document-type/7b8cc610-2bcd-4eab-afa2-8cd7adbd4d4f> 32 33)
+    (<http://themis.vlaanderen.be/id/concept/document-type/d638e0dc-c879-4a75-9485-9e6970a83d67> 33 34)
+    (<http://themis.vlaanderen.be/id/concept/document-type/e9e8ec50-c6fd-44ac-bc34-e5e4cdb0294e> 34 35)
+    (<http://themis.vlaanderen.be/id/concept/document-type/d3a616a1-4734-409d-be51-30917c91eb84> 35 36)
+    (<http://themis.vlaanderen.be/id/concept/document-type/cf471294-af65-455c-a200-86b7fd70751a> 36 37)
+    (<http://themis.vlaanderen.be/id/concept/document-type/6b4e9376-449a-43f8-8027-6dc63494057b> 37 38)
+    (<https://data.vlaanderen.be/id/concept/AardWetgeving/Protocol> 38 39)
+    (<http://themis.vlaanderen.be/id/concept/document-type/2fef8c6a-ca60-4cd5-97b3-578144aece0a> 39 40)
+    (<http://themis.vlaanderen.be/id/concept/document-type/0ed0785c-f427-4bc0-8507-72eb2a7b5454> 40 41)
+    (<http://themis.vlaanderen.be/id/concept/document-type/83f7dc8b-b763-47c4-8a21-f7e43b879ad2> 41 42)
+    (<http://themis.vlaanderen.be/id/concept/document-type/59b81be7-26c9-4a08-9a51-ce23ce83a133> 42 43)
+    (<http://themis.vlaanderen.be/id/concept/document-type/205bb487-127c-43c6-9a8a-9b397a99f056> 43 44)
+    (<http://themis.vlaanderen.be/id/concept/document-type/8ae796bd-690a-4ed6-855c-c4572e883066> 44 45)
+    (<http://themis.vlaanderen.be/id/concept/document-type/3f6ed920-7cd0-4296-a5b7-eb06d77ca5f4> 45 46)
+    (<http://themis.vlaanderen.be/id/concept/document-type/361f3132-d763-412d-8d16-609ad664055c> 46 47)
+  }
+}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4574

Adds a new concept to the document types concept scheme to represent the Bekrachting document type (voorblad that a minister signs that "contains" the decreet).