### PR TITLE
chore: enable extended-logging for VP service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -463,6 +463,10 @@ services:
     environment:
       - ENABLE_SENDING_TO_VP_API=true
       - ENABLE_DEBUG_FILE_WRITING=false
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *extended-logging
   agenda-submission:
     image: kanselarij/agenda-submission-service:1.1.1
     labels:


### PR DESCRIPTION
This is useful to ensure we have enough log history, since this is quite a chatty service.