### PR TITLE
KAS-4660: Add fixed migration for prov:Activity

### DIFF
--- a/config/migrations/20240529120916-add-prov-activity-type-to-indieningsactiviteit.sparql
+++ b/config/migrations/20240529120916-add-prov-activity-type-to-indieningsactiviteit.sparql
@@ -1,0 +1,17 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+
+INSERT { GRAPH ?g { ?s a prov:Activity } }
+WHERE {
+  VALUES (?type) {
+    (ext:Indieningsactiviteit)
+    (ext:AgendaStatusActivity)
+  }
+  GRAPH ?g {
+    ?s a ?type .
+    FILTER NOT EXISTS { ?s a prov:Activity }
+  }
+}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4660

Now it correctly picks up submission activities as well as agenda status activities