### PR TITLE
Feature/kas 4831 start diependaele i

### DIFF
--- a/config/migrations/20240930103855-end-legislatuur.sparql
+++ b/config/migrations/20240930103855-end-legislatuur.sparql
@@ -1,0 +1,39 @@
+
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0700> skos:prefLabel ?oldLabel .
+    }
+}
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0700> skos:prefLabel ?newLabel ;
+            prov:qualifiedInvalidation <http://themis.vlaanderen.be/id/opheffing/9a71df42-7f07-11ef-acc8-0242ac110003> .
+        <http://themis.vlaanderen.be/id/opheffing/9a71df42-7f07-11ef-acc8-0242ac110003> a prov:Invalidation ;
+            mu:uuid """9a71df42-7f07-11ef-acc8-0242ac110003""" ;
+            prov:atTime ?end_date .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0700> a besluit:Bestuursorgaan ;
+            prov:qualifiedGeneration / prov:atTime ?start_date .
+        <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0700> skos:prefLabel ?oldLabel .
+        BIND(xsd:dateTime(?start_date) AS ?start_datetime)
+        BIND(CONCAT(STR(DAY(?start_datetime)), "/", STR(MONTH(?start_datetime)), "/", STR(YEAR(?start_datetime))) AS ?label_start_date)
+        BIND("2024-09-30T00:00:00+02:00"^^xsd:dateTime AS ?end_datetime)
+        BIND(xsd:dateTime(?end_datetime) AS ?end_date)
+        BIND(CONCAT(STR(DAY(?end_datetime)), "/", STR(MONTH(?end_datetime)), "/", STR(YEAR(?end_datetime))) AS ?label_end_date)
+        BIND(CONCAT("Vlaamse Regering ", ?label_start_date, " - ", ?label_end_date) AS ?newLabel)
+    }
+}
+

--- a/config/migrations/20240930104018-end_regeringssamenstelling.sparql
+++ b/config/migrations/20240930104018-end_regeringssamenstelling.sparql
@@ -1,0 +1,38 @@
+
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0706> prov:qualifiedInvalidation <http://themis.vlaanderen.be/id/opheffing/a73fbcda-7f07-11ef-8291-0242ac110003> .
+        <http://themis.vlaanderen.be/id/opheffing/a73fbcda-7f07-11ef-8291-0242ac110003> a prov:Invalidation ;
+            mu:uuid """a73fbcda-7f07-11ef-8291-0242ac110003""" ;
+            prov:atTime "2024-09-30T00:00:00+02:00"^^xsd:dateTime .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0706> a besluit:Bestuursorgaan .
+    }
+}
+;
+
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        ?mandatee mandaat:einde "2024-09-30T00:00:00+02:00"^^xsd:dateTime .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0706> a besluit:Bestuursorgaan ;
+            prov:hadMember ?mandatee .
+        ?mandatee a mandaat:Mandataris .
+        FILTER NOT EXISTS { ?mandatee mandaat:einde ?mandatee_end . }
+    }
+}

--- a/config/migrations/20240930104133-start-legislatuur-with-secretary.sparql
+++ b/config/migrations/20240930104133-start-legislatuur-with-secretary.sparql
@@ -1,0 +1,51 @@
+
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT DATA {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/bestuursorgaan/cfc37e6c-7f07-11ef-a9c1-0242ac110003> a besluit:Bestuursorgaan ;
+            mu:uuid """cfc37e6c-7f07-11ef-a9c1-0242ac110003""" ;
+            skos:prefLabel """Vlaamse Regering 30/09/2024 - ...""" ;
+            generiek:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> ;
+            prov:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/cfc381c8-7f07-11ef-a9c1-0242ac110003> .
+        <http://themis.vlaanderen.be/id/creatie/cfc381c8-7f07-11ef-a9c1-0242ac110003> a prov:Generation ;
+            mu:uuid """cfc381c8-7f07-11ef-a9c1-0242ac110003""" ;
+            prov:atTime "2024-09-30T00:00:00+02:00"^^xsd:dateTime .
+    }
+}
+;
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+
+INSERT DATA {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+
+        <http://themis.vlaanderen.be/id/mandaat/cfc39794-7f07-11ef-a9c1-0242ac110003> a mandaat:Mandaat ;
+        	mu:uuid	"""cfc39794-7f07-11ef-a9c1-0242ac110003""" ;
+        	org:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de> . #MP
+        <http://themis.vlaanderen.be/id/bestuursorgaan/cfc37e6c-7f07-11ef-a9c1-0242ac110003> org:hasPost <http://themis.vlaanderen.be/id/mandaat/cfc39794-7f07-11ef-a9c1-0242ac110003> .
+        <http://themis.vlaanderen.be/id/mandaat/cfc39abe-7f07-11ef-a9c1-0242ac110003> a mandaat:Mandaat ;
+        	mu:uuid	"""cfc39abe-7f07-11ef-a9c1-0242ac110003""" ;
+        	org:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df> . #Vice
+        <http://themis.vlaanderen.be/id/bestuursorgaan/cfc37e6c-7f07-11ef-a9c1-0242ac110003> org:hasPost <http://themis.vlaanderen.be/id/mandaat/cfc39abe-7f07-11ef-a9c1-0242ac110003> .
+        <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> a mandaat:Mandaat ;
+        	mu:uuid	"""cfc39dfc-7f07-11ef-a9c1-0242ac110003""" ;
+        	org:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0> . #Vlaams
+        <http://themis.vlaanderen.be/id/bestuursorgaan/cfc37e6c-7f07-11ef-a9c1-0242ac110003> org:hasPost <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
+        <http://themis.vlaanderen.be/id/mandaat/cfc3a072-7f07-11ef-a9c1-0242ac110003> a mandaat:Mandaat ;
+        	mu:uuid	"""cfc3a072-7f07-11ef-a9c1-0242ac110003""" ;
+        	org:role <http://themis.vlaanderen.be/id/bestuursfunctie/9d5ebfb9-3829-4b1f-a2a8-15033f7e2097> . #Secretaris
+        <http://themis.vlaanderen.be/id/bestuursorgaan/cfc37e6c-7f07-11ef-a9c1-0242ac110003> org:hasPost <http://themis.vlaanderen.be/id/mandaat/cfc3a072-7f07-11ef-a9c1-0242ac110003> .
+        <http://themis.vlaanderen.be/id/mandaat/cfc3a2de-7f07-11ef-a9c1-0242ac110003> a mandaat:Mandaat ;
+        	mu:uuid	"""cfc3a2de-7f07-11ef-a9c1-0242ac110003""" ;
+        	org:role <http://themis.vlaanderen.be/id/bestuursfunctie/cfa6ed74-bb6f-4d4c-b905-9a205be135d7> . #Waarnemend
+        <http://themis.vlaanderen.be/id/bestuursorgaan/cfc37e6c-7f07-11ef-a9c1-0242ac110003> org:hasPost <http://themis.vlaanderen.be/id/mandaat/cfc3a2de-7f07-11ef-a9c1-0242ac110003> .
+    }
+}

--- a/config/migrations/20240930105445-start-samenstelling.sparql
+++ b/config/migrations/20240930105445-start-samenstelling.sparql
@@ -1,0 +1,27 @@
+
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/bestuursorgaan/ba398a44-7f09-11ef-a2b2-0242ac110003> a besluit:Bestuursorgaan ;
+            mu:uuid """ba398a44-7f09-11ef-a2b2-0242ac110003""" ;
+            skos:prefLabel """Diependaele I""" ;
+            generiek:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/cfc37e6c-7f07-11ef-a9c1-0242ac110003> ;
+            prov:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/ba398c4c-7f09-11ef-a2b2-0242ac110003> .
+        <http://themis.vlaanderen.be/id/creatie/ba398c4c-7f09-11ef-a2b2-0242ac110003> a prov:Generation ;
+            mu:uuid """ba398c4c-7f09-11ef-a2b2-0242ac110003""" ;
+            prov:atTime "2024-09-30T00:00:00+02:00"^^xsd:dateTime .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://themis.vlaanderen.be/id/bestuursorgaan/cfc37e6c-7f07-11ef-a9c1-0242ac110003> a besluit:Bestuursorgaan .
+    }
+}
+

--- a/config/migrations/20240930105628-new-minister-data.graph
+++ b/config/migrations/20240930105628-new-minister-data.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20240930105628-new-minister-data.ttl
+++ b/config/migrations/20240930105628-new-minister-data.ttl
@@ -24,7 +24,7 @@
     ns1:rangorde 2 ;
     ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
     ns2:uuid "0044cea8-9e92-49e5-9097-2b59f2980cdd" ;
-    dcterms:title "Vlaams minister van bevoegdheden Depraetere" ;
+    dcterms:title "Vlaams minister van Wonen, Energie en Klimaat, Toerisme en Jeugd" ;
     org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
 
 <http://themis.vlaanderen.be/id/mandatee/01dd1477-5a37-4343-9cce-0d1bef1ba993> a ns1:Mandataris ;
@@ -39,7 +39,7 @@
     ns1:rangorde 6 ;
     ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
     ns2:uuid "0e2e3e1f-03b4-4457-a96f-8da6d8552758" ;
-    dcterms:title "Vlaams minister van bevoegdheden Gennez" ;
+    dcterms:title "Vlaams minister van Welzijn en Armoedebestrijding, Cultuur en Gelijke Kansen" ;
     org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
 
 <http://themis.vlaanderen.be/id/mandatee/22501431-8d46-4fb5-b1c4-9b39b8554e32> a ns1:Mandataris ;
@@ -54,7 +54,7 @@
     ns1:rangorde 9 ;
     ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
     ns2:uuid "37a35ad6-643c-4a69-b493-21aa93973256" ;
-    dcterms:title "Vlaams minister van bevoegdheden Van Achter" ;
+    dcterms:title "Vlaams minister van Brussel en Media" ;
     org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
 
 <http://themis.vlaanderen.be/id/mandatee/3bd27bb7-3235-4418-96ff-672ae71c1488> a ns1:Mandataris ;
@@ -62,7 +62,7 @@
     ns1:rangorde 5 ;
     ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
     ns2:uuid "3bd27bb7-3235-4418-96ff-672ae71c1488" ;
-    dcterms:title "Vlaams minister van bevoegdheden Demir" ;
+    dcterms:title "Vlaams minister van Onderwijs, Justitie en Werk" ;
     org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
 
 <http://themis.vlaanderen.be/id/mandatee/4bbf9edb-89ce-4b46-9cb9-d2782250318c> a ns1:Mandataris ;
@@ -70,7 +70,7 @@
     ns1:rangorde 8 ;
     ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
     ns2:uuid "4bbf9edb-89ce-4b46-9cb9-d2782250318c" ;
-    dcterms:title "Vlaams minister van bevoegdheden De Ridder" ;
+    dcterms:title "Vlaams minister van Mobiliteit, Openbare Werken, Havens en Sport" ;
     org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
 
 <http://themis.vlaanderen.be/id/mandatee/520449e7-e0b0-472c-a673-f71ce46f8a45> a ns1:Mandataris ;
@@ -78,7 +78,7 @@
     ns1:rangorde 7 ;
     ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
     ns2:uuid "520449e7-e0b0-472c-a673-f71ce46f8a45" ;
-    dcterms:title "Vlaams minister van bevoegdheden Brouns" ;
+    dcterms:title "Vlaams minister van Omgeving en Landbouw" ;
     org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
 
 <http://themis.vlaanderen.be/id/mandatee/5499a908-3cf0-488a-ad63-2d705065cb41> a ns1:Mandataris ;
@@ -86,7 +86,7 @@
     ns1:rangorde 3 ;
     ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
     ns2:uuid "5499a908-3cf0-488a-ad63-2d705065cb41" ;
-    dcterms:title "Vlaams minister van bevoegdheden Crevits" ;
+    dcterms:title "Vlaams minister van Binnenland, Steden- en Plattelandsbeleid, Samenleven, Integratie en Inburgering, Bestuurszaken, Sociale Economie en Zeevisserij" ;
     org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
 
 <http://themis.vlaanderen.be/id/mandatee/81c8c1b5-5495-4337-9017-7a3ef1591e9a> a ns1:Mandataris ;
@@ -101,7 +101,7 @@
     ns1:rangorde 1 ;
     ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
     ns2:uuid "84e53398-73bc-4cc3-84a4-a902ea658d6b" ;
-    dcterms:title "Vlaams minister van bevoegdheden Diependaele" ;
+    dcterms:title "Vlaams minister van Economie, Innovatie en Industrie, Buitenlandse Zaken, Digitalisering en Facilitair Management" ;
     org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
 
 <http://themis.vlaanderen.be/id/mandatee/a712e06b-457c-4ae6-82d3-deefa22f038e> a ns1:Mandataris ;
@@ -117,7 +117,7 @@
     ns1:rangorde 4 ;
     ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
     ns2:uuid "b03da548-417f-4640-80ff-0b779fe76a67" ;
-    dcterms:title "Vlaams minister van bevoegdheden Weyts" ;
+    dcterms:title "Vlaams minister van Begroting en Financiën, Vlaamse Rand, Onroerend Erfgoed en Dierenwelzijn" ;
     org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
 
 <http://themis.vlaanderen.be/id/persoon/a6849e22-eead-44e5-8828-a5876e03fdc9> a <http://www.w3.org/ns/person#Person>;

--- a/config/migrations/20240930105628-new-minister-data.ttl
+++ b/config/migrations/20240930105628-new-minister-data.ttl
@@ -1,0 +1,141 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ns1: <http://data.vlaanderen.be/ns/mandaat#> .
+@prefix ns2: <http://mu.semte.ch/vocabularies/core/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/ba398a44-7f09-11ef-a2b2-0242ac110003> prov:hadMember <http://themis.vlaanderen.be/id/mandatee/0044cea8-9e92-49e5-9097-2b59f2980cdd>,
+        <http://themis.vlaanderen.be/id/mandatee/01dd1477-5a37-4343-9cce-0d1bef1ba993>,
+        <http://themis.vlaanderen.be/id/mandatee/0e2e3e1f-03b4-4457-a96f-8da6d8552758>,
+        <http://themis.vlaanderen.be/id/mandatee/22501431-8d46-4fb5-b1c4-9b39b8554e32>,
+        <http://themis.vlaanderen.be/id/mandatee/37a35ad6-643c-4a69-b493-21aa93973256>,
+        <http://themis.vlaanderen.be/id/mandatee/3bd27bb7-3235-4418-96ff-672ae71c1488>,
+        <http://themis.vlaanderen.be/id/mandatee/4bbf9edb-89ce-4b46-9cb9-d2782250318c>,
+        <http://themis.vlaanderen.be/id/mandatee/520449e7-e0b0-472c-a673-f71ce46f8a45>,
+        <http://themis.vlaanderen.be/id/mandatee/5499a908-3cf0-488a-ad63-2d705065cb41>,
+        <http://themis.vlaanderen.be/id/mandatee/81c8c1b5-5495-4337-9017-7a3ef1591e9a>,
+        <http://themis.vlaanderen.be/id/mandatee/84e53398-73bc-4cc3-84a4-a902ea658d6b>,
+        <http://themis.vlaanderen.be/id/mandatee/a712e06b-457c-4ae6-82d3-deefa22f038e>,
+        <http://themis.vlaanderen.be/id/mandatee/b03da548-417f-4640-80ff-0b779fe76a67> .
+
+<http://themis.vlaanderen.be/id/mandatee/0044cea8-9e92-49e5-9097-2b59f2980cdd> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/a6849e22-eead-44e5-8828-a5876e03fdc9> ;
+    ns1:rangorde 2 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "0044cea8-9e92-49e5-9097-2b59f2980cdd" ;
+    dcterms:title "Vlaams minister van bevoegdheden Depraetere" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/01dd1477-5a37-4343-9cce-0d1bef1ba993> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns1:rangorde 3 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "01dd1477-5a37-4343-9cce-0d1bef1ba993" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39abe-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/0e2e3e1f-03b4-4457-a96f-8da6d8552758> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/d57d67a5-2468-4ecf-b193-cfc431cb7af4> ;
+    ns1:rangorde 6 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "0e2e3e1f-03b4-4457-a96f-8da6d8552758" ;
+    dcterms:title "Vlaams minister van bevoegdheden Gennez" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/22501431-8d46-4fb5-b1c4-9b39b8554e32> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns1:rangorde 4 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "22501431-8d46-4fb5-b1c4-9b39b8554e32" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39abe-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/37a35ad6-643c-4a69-b493-21aa93973256> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/18097326-6499-41ea-bcee-146bd963ddc6> ;
+    ns1:rangorde 9 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "37a35ad6-643c-4a69-b493-21aa93973256" ;
+    dcterms:title "Vlaams minister van bevoegdheden Van Achter" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/3bd27bb7-3235-4418-96ff-672ae71c1488> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0714> ;
+    ns1:rangorde 5 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "3bd27bb7-3235-4418-96ff-672ae71c1488" ;
+    dcterms:title "Vlaams minister van bevoegdheden Demir" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/4bbf9edb-89ce-4b46-9cb9-d2782250318c> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/e407797c-95ad-4595-ac74-fc247513ea88> ;
+    ns1:rangorde 8 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "4bbf9edb-89ce-4b46-9cb9-d2782250318c" ;
+    dcterms:title "Vlaams minister van bevoegdheden De Ridder" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/520449e7-e0b0-472c-a673-f71ce46f8a45> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/74888cf5-6e19-4cf3-abf1-eeb9af999922> ;
+    ns1:rangorde 7 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "520449e7-e0b0-472c-a673-f71ce46f8a45" ;
+    dcterms:title "Vlaams minister van bevoegdheden Brouns" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/5499a908-3cf0-488a-ad63-2d705065cb41> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns1:rangorde 3 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "5499a908-3cf0-488a-ad63-2d705065cb41" ;
+    dcterms:title "Vlaams minister van bevoegdheden Crevits" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/81c8c1b5-5495-4337-9017-7a3ef1591e9a> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/a6849e22-eead-44e5-8828-a5876e03fdc9> ;
+    ns1:rangorde 2 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "81c8c1b5-5495-4337-9017-7a3ef1591e9a" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39abe-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/84e53398-73bc-4cc3-84a4-a902ea658d6b> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071a> ;
+    ns1:rangorde 1 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "84e53398-73bc-4cc3-84a4-a902ea658d6b" ;
+    dcterms:title "Vlaams minister van bevoegdheden Diependaele" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/a712e06b-457c-4ae6-82d3-deefa22f038e> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071a> ;
+    ns1:rangorde 1 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "a712e06b-457c-4ae6-82d3-deefa22f038e" ;
+    dcterms:title "Minister-president van de Vlaamse Regering" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39794-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/mandatee/b03da548-417f-4640-80ff-0b779fe76a67> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns1:rangorde 4 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "b03da548-417f-4640-80ff-0b779fe76a67" ;
+    dcterms:title "Vlaams minister van bevoegdheden Weyts" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc39dfc-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/persoon/a6849e22-eead-44e5-8828-a5876e03fdc9> a <http://www.w3.org/ns/person#Person>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6849e22-eead-44e5-8828-a5876e03fdc9";
+  <http://xmlns.com/foaf/0.1/familyName> "Depraetere";
+  <https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam> "Melissa" .
+
+<http://themis.vlaanderen.be/id/persoon/d57d67a5-2468-4ecf-b193-cfc431cb7af4> a <http://www.w3.org/ns/person#Person>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d57d67a5-2468-4ecf-b193-cfc431cb7af4";
+  <http://xmlns.com/foaf/0.1/familyName> "Gennez";
+  <https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam> "Caroline" .
+
+<http://themis.vlaanderen.be/id/persoon/e407797c-95ad-4595-ac74-fc247513ea88> a <http://www.w3.org/ns/person#Person>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e407797c-95ad-4595-ac74-fc247513ea88";
+  <http://xmlns.com/foaf/0.1/familyName> "De Ridder";
+  <https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam> "Annick" .
+
+<http://themis.vlaanderen.be/id/persoon/18097326-6499-41ea-bcee-146bd963ddc6> a <http://www.w3.org/ns/person#Person>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18097326-6499-41ea-bcee-146bd963ddc6";
+  <http://xmlns.com/foaf/0.1/familyName> "Van Achter";
+  <https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam> "Cieltje" .

--- a/config/migrations/20240930111245-new-secretaris-data.graph
+++ b/config/migrations/20240930111245-new-secretaris-data.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20240930111245-new-secretaris-data.ttl
+++ b/config/migrations/20240930111245-new-secretaris-data.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ns1: <http://data.vlaanderen.be/ns/mandaat#> .
+@prefix ns2: <http://mu.semte.ch/vocabularies/core/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/ba398a44-7f09-11ef-a2b2-0242ac110003> prov:hadMember <http://themis.vlaanderen.be/id/mandatee/32eb28aa-445e-4cc8-b3a0-03f32d7dd28a> .
+
+<http://themis.vlaanderen.be/id/mandatee/32eb28aa-445e-4cc8-b3a0-03f32d7dd28a> a ns1:Mandataris ;
+    ns1:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/a1713a38-c8fa-47e2-b844-a962eec8581d> ;
+    ns1:rangorde 1 ;
+    ns1:start "2024-09-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns2:uuid "32eb28aa-445e-4cc8-b3a0-03f32d7dd28a" ;
+    dcterms:title "Secretaris" ;
+    org:holds <http://themis.vlaanderen.be/id/mandaat/cfc3a072-7f07-11ef-a9c1-0242ac110003> .
+
+<http://themis.vlaanderen.be/id/persoon/a1713a38-c8fa-47e2-b844-a962eec8581d> a <http://www.w3.org/ns/person#Person>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1713a38-c8fa-47e2-b844-a962eec8581d";
+  <http://xmlns.com/foaf/0.1/familyName> "Vanholle";
+  <https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam> "Maarten" .

--- a/config/migrations/20240930200000-new-minister-titles.sparql
+++ b/config/migrations/20240930200000-new-minister-titles.sparql
@@ -1,12 +1,3 @@
-# A person carrying a special mandate, such a "minister-president" or "viceminister-president",
-# is modelled as 2 mandatees: 1 regular "minister" and 1 with the special title.
-# Most tasks (agenda-item relationships ...) are executed in the capacity of the regular minister.
-# When displaying the minister in relation to some subject however,
-# it is preferred to always show the special mandate's title rather than the regular "minister".
-#
-# Below query adds a Kaleidos/Valvas-specific predicate to mandatees that contains the title (including name)
-# of a mandatee in the way it is desired to show on the newsletter/valvas website.
-
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX org: <http://www.w3.org/ns/org#>
 PREFIX person: <http://www.w3.org/ns/person#>


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4831

WIP migrations, mandatee titles are not known yet.
Only 1 secretary is known.
Rank of mandatees should be set (in stone?)

TODO: Change the titles before migrating (change on themis first and copy the `20240930105628-new-minister-data.ttl` file to kaleidos)