### PR TITLE
feat: upgrade Virtuoso

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     labels:
       - "logging=true"
   triplestore:
-    image: redpencil/virtuoso:1.0.0
+    image: redpencil/virtuoso:1.2.0
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
Bumps Virtuoso to the image version 1.2.0

https://kanselarij.atlassian.net/browse/KAS-4510

For upgrade steps, see draaiboek: https://kanselarij.atlassian.net/wiki/spaces/SPECSDOCS/pages/2281078785/Deployment+SPRINT+132-+xx+xx+xxxx