### PR TITLE
set yggdrasil to feature branch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,7 +194,7 @@ services:
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:5.23.0
+    image: kanselarij/yggdrasil:feature-simplified-distribution-subquery
     logging: *default-logging
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,7 +194,7 @@ services:
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:feature-simplified-distribution-subquery
+    image: kanselarij/yggdrasil:feature-stricter-typing
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
:warning: started from ACC.

When deploying, remove the override in docker.compose.yml on ACC and PROD servers
Possibly add an override for `VIRTUOSO_RESOURCE_PAGE_SIZE` (ACC and PROD have .init file edited so they can handle 25000) It was defaulted to 10000.
Should only be needed if we get more than 10000 of a specific `a ?type` on resource collection.
The offset in the queries should work