### PR TITLE
KAS-4998 fix: bump sparql-parser for file service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     labels:
       - "logging=true"
   database:
-    image: semtech/sparql-parser:0.0.13
+    image: semtech/sparql-parser:0.0.14
     volumes:
       - ./config/new-authorization:/config
       - ./data/mu-cl-authorization:/data/


### PR DESCRIPTION
An issue with file metadata lingering around was reported.  Bumping sparql-parser fixes the issue at hand and should ensure metadata is only available for files which are still available on disk.  Does not clean up existing files which don't have an on-disk counterpart.