### PR TITLE
add dispatcher config for maintenance mode

### DIFF
--- a/config/dispatcher-maintenance/dispatcher.ex
+++ b/config/dispatcher-maintenance/dispatcher.ex
@@ -1,0 +1,24 @@
+defmodule Dispatcher do
+  use Matcher
+
+  define_accept_types [
+    json: [ "application/json", "application/vnd.api+json" ],
+    html: [ "text/html", "application/xhtml+html"],
+    css: [ "text/css" ],
+    any: [ "*/*" ],
+  ]
+
+  define_layers [ :frontend, :api, :not_found ]
+
+  @frontend %{ accept: [ :any ], layer: :frontend }
+  @json_service %{ accept: [ :json ], layer: :api }
+  @not_found %{ accept: [ :any ], layer: :not_found }
+
+
+  ## Fallback
+
+  match "/*_path", @not_found do
+    Proxy.forward conn, [], "http://frontend/index.html"
+  end
+
+ end


### PR DESCRIPTION
when rebuilding yggdrasil graphs, most of the stack is down.
When users were logged in and stay logged in, the maintenance image is not shown properly because triplestore/database is up, but resource/cache is not.
Dispatcher is throwing too many errors and you get a "500: website could not process your request" instead of our maintenance image.

A different dispatcher config in maintenance mode should be enough?
Tried it live and it worked, dispatcher was still throwing errors but maintenance image was showing.
