### PR TITLE
KAS-5030 Added a route to manually strip pdf signatures

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -667,6 +667,11 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://document-stamping/"
   end
 
+  ### PDF Signature Remover
+  match "/pdf-signature-remover/pieces/:piece_id/strip", @json_service do
+    Proxy.forward conn, [], "http://pdf-signature-remover/pieces/" <> piece_id <> "/strip"
+  end
+
   ## Fallback
 
   get "/*_path", %{ layer: :api, accept: %{ html: true } } do


### PR DESCRIPTION
See https://github.com/kanselarij-vlaanderen/pdf-signature-remover/pull/4 for service PR.
This one adds the dispatcher route.