### PR TITLE
KAS-5025 update some semtech services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,7 @@ services:
     labels:
       - "logging=true"
   resource:
-    image: semtech/mu-cl-resources:1.27.0
+    image: semtech/mu-cl-resources:1.26.0
     environment:
       CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
       LISP_DYNAMIC_SPACE_SIZE: "1024" # 1GB by default, increase to 8GB on systems with a lot of data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - ./config/project-scripts:/app/scripts
   identifier:
-    image: semtech/mu-identifier:1.10.0
+    image: semtech/mu-identifier:1.10.3
     logging: *default-logging
     restart: always
     labels:
@@ -42,7 +42,7 @@ services:
     labels:
       - "logging=true"
   migrations:
-    image: semtech/mu-migrations-service:0.7.0
+    image: semtech/mu-migrations-service:0.9.0
     volumes:
       - ./config/migrations:/data/migrations
     environment:
@@ -75,7 +75,7 @@ services:
     labels:
       - "logging=true"
   search:
-    image: semtech/mu-search:0.9.3
+    image: semtech/mu-search:0.10.0
     volumes:
       - ./config/search:/config
       - ./data/files:/data
@@ -103,7 +103,7 @@ services:
     labels:
       - "logging=true"
   delta-notifier:
-    image: semtech/mu-delta-notifier:0.3.1
+    image: semtech/mu-delta-notifier:0.4.0
     volumes:
       - ./config/delta:/config
     logging: *default-logging
@@ -119,7 +119,7 @@ services:
     environment:
       CONCEPT_BACKEND_URL: "http://forever-cache/"
   cache:
-    image: semtech/mu-cache:2.0.1
+    image: semtech/mu-cache:2.0.2
     links:
       - resource:backend
     logging: *default-logging
@@ -127,7 +127,7 @@ services:
     labels:
       - "logging=true"
   forever-cache:
-    image: semtech/mu-cache:2.0.1
+    image: semtech/mu-cache:2.0.2
     links:
       - resource:backend
     logging: *default-logging
@@ -135,7 +135,7 @@ services:
     labels:
       - "logging=true"
   resource:
-    image: semtech/mu-cl-resources:1.25.0
+    image: semtech/mu-cl-resources:1.27.0
     environment:
       CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
       LISP_DYNAMIC_SPACE_SIZE: "1024" # 1GB by default, increase to 8GB on systems with a lot of data
@@ -146,7 +146,7 @@ services:
     labels:
       - "logging=true"
   file:
-    image: semtech/mu-file-service:3.3.0
+    image: semtech/mu-file-service:3.4.0
     environment:
       FILE_RESOURCE_BASE: "http://themis.vlaanderen.be/id/bestand/"
     volumes:
@@ -502,7 +502,7 @@ services:
     restart: always
     logging: *default-logging
   draft-file:
-    image: kanselarij/draft-file-service:0.0.1
+    image: kanselarij/draft-file-service:0.0.3
     environment:
       FILE_RESOURCE_BASE: "http://themis.vlaanderen.be/id/voorlopig-bestand/"
     volumes:


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5025

- updated semtech services


note: `public-file-service` (used for export-file and public-file) is a "dirty" fork of `mu-file-service` (many commits ahead and behind).
Still want/need to update this, many endpoints have been removed by us. Many changes to those deleted endpoints have been made by them. so slow conflict resolution will be the way to go.

- [ ] make sure jenkins has at least a few green runs before merge