### PR TITLE
KAS-5095 fix rdfs prefix should be http

### DIFF
--- a/config/migrations/20250819120000-change-https-to-http-rdfs.sparql
+++ b/config/migrations/20250819120000-change-https-to-http-rdfs.sparql
@@ -1,0 +1,21 @@
+PREFIX oldRdfs: <https://www.w3.org/2000/01/rdf-schema#>
+PREFIX newRdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+
+DELETE {
+  GRAPH ?g {
+    ?s oldRdfs:comment ?o .
+  }
+}
+
+INSERT {
+  GRAPH ?g {
+    ?s newRdfs:comment ?o .
+  }
+}
+
+WHERE {
+  GRAPH ?g {
+    ?s oldRdfs:comment ?o .
+  }
+}

--- a/config/resources/publicatie-domain.json
+++ b/config/resources/publicatie-domain.json
@@ -6,7 +6,7 @@
     "schema": "http://schema.org/",
     "dct": "http://purl.org/dc/terms/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
-    "rdfs": "https://www.w3.org/2000/01/rdf-schema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "adms": "http://www.w3.org/ns/adms#",
     "dossier": "https://data.vlaanderen.be/ns/dossier#",
     "euvoc": "http://publications.europa.eu/ontology/euvoc#",

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -65,7 +65,7 @@
 (add-prefix "person" "http://www.w3.org/ns/person#")
 (add-prefix "prov" "http://www.w3.org/ns/prov#")
 (add-prefix "regorg" "https://www.w3.org/ns/regorg#")
-(add-prefix "rdfs" "https://www.w3.org/2000/01/rdf-schema#")
+(add-prefix "rdfs" "http://www.w3.org/2000/01/rdf-schema#")
 (add-prefix "schema" "http://schema.org/")
 (add-prefix "skos" "http://www.w3.org/2004/02/skos/core#")
 (add-prefix "toezicht" "http://mu.semte.ch/vocabularies/ext/supervision/")

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -758,7 +758,7 @@
         "title": "http://purl.org/dc/terms/title",
         "shortTitle": "http://purl.org/dc/terms/alternative",
         "modified": "http://purl.org/dc/terms/modified",
-        "remark": "https://www.w3.org/2000/01/rdf-schema#comment",
+        "remark": "http://www.w3.org/2000/01/rdf-schema#comment",
         "identification": [
           "http://www.w3.org/ns/adms#identifier",
           "http://www.w3.org/2004/02/skos/core#notation"

--- a/doc/prefixes.sparql
+++ b/doc/prefixes.sparql
@@ -34,7 +34,7 @@ PREFIX pav: <http://purl.org/pav/>
 PREFIX person: <http://www.w3.org/ns/person#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX regorg: <https://www.w3.org/ns/regorg#>
-PREFIX rdfs: <https://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX toezicht: <http://mu.semte.ch/vocabularies/ext/supervision/>


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5095

RDFS prefix is used with both **https** (incorrect) and **http** (correct)
Fixed models and search to use the correct one.
Added migration to fix the 1 predicate that is affected (mainly publication flow comments)
requires yggdrasil rebuild (see those PR's) and search index rebuild