### PR TITLE
Update docker command and files

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 x-logging:
   &default-logging
   driver: "json-file"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   triplestore:
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 x-logging:
   &default-logging
   driver: "json-file"

--- a/scripts/delete-cache.sh
+++ b/scripts/delete-cache.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 echo "warning this will run queries on the triplestore and delete containers, you have 5 seconds to press ctrl+c"
 sleep 5
-docker-compose rm -fs elasticsearch search
-rm -rf data/elasticsearch
-docker-compose exec -T triplestore isql-v <<EOF
+docker compose rm -fs elasticsearch search
+sudo rm -rf data/elasticsearch
+docker compose exec -T triplestore isql-v <<EOF
 SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };
 exec('checkpoint');
 exit;
 EOF
-docker-compose up -d --remove-orphan elasticsearch search
+docker compose up -d --remove-orphan elasticsearch search

--- a/scripts/reset-elastic-test.sh
+++ b/scripts/reset-elastic-test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 echo "warning this will run queries on the triplestore and delete containers, you have 5 seconds to press ctrl+c"
 sleep 5
-docker-compose -f docker-compose.yml -f docker-compose.development.yml -f docker-compose.test.yml -f docker-compose.override.yml rm -fs elasticsearch search
+docker compose -f docker-compose.yml -f docker-compose.development.yml -f docker-compose.test.yml -f docker-compose.override.yml rm -fs elasticsearch search
 rm -rf testdata/elasticsearch
-docker-compose -f docker-compose.yml -f docker-compose.development.yml -f docker-compose.test.yml -f docker-compose.override.yml exec -T triplestore isql-v <<EOF
+docker compose -f docker-compose.yml -f docker-compose.development.yml -f docker-compose.test.yml -f docker-compose.override.yml exec -T triplestore isql-v <<EOF
 SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };
 exec('checkpoint');
 exit;
 EOF
-docker-compose -f docker-compose.yml -f docker-compose.development.yml -f docker-compose.test.yml -f docker-compose.override.yml up -d  --remove-orphans
+docker compose -f docker-compose.yml -f docker-compose.development.yml -f docker-compose.test.yml -f docker-compose.override.yml up -d  --remove-orphans

--- a/scripts/reset-elastic.sh
+++ b/scripts/reset-elastic.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 echo "warning this will run queries on the triplestore and delete containers, you have 5 seconds to press ctrl+c"
 sleep 5
-docker-compose rm -fs elasticsearch search
-rm -rf data/elasticsearch
-docker-compose exec -T triplestore isql-v <<EOF
+docker compose rm -fs elasticsearch search
+sudo rm -rf data/elasticsearch
+docker compose exec -T triplestore isql-v <<EOF
 SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };
 exec('checkpoint');
 exit;
 EOF
-docker-compose up -d --remove-orphans
+docker compose up -d --remove-orphans

--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo 'Update and recreate all services (which also runs migrations)';
 echo '--------------------';
-docker-compose down && docker-compose pull && docker-compose up -d --remove-orphan
+docker compose down && docker compose pull && docker compose up -d --remove-orphan

--- a/scripts/update-frontend.sh
+++ b/scripts/update-frontend.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose pull frontend && docker-compose up -d frontend
+docker compose pull frontend && docker compose up -d frontend


### PR DESCRIPTION
Changes to adhere to modern Docker versions:
- use `docker compose` command instead of `docker-compose` in scripts
- remove version specification from `docker-compose.yml` files

All servers have been upgraded and have support for these changes now.