### PR TITLE
Cleanup of docker-compose.development.yml

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -120,8 +120,6 @@ services:
   publication-report:
     restart: "no"
   decision-extraction:
-    environment:
-      - NODE_ENV=development
   delta-producer:
     image: lblod/sink-service:1.0.0
     restart: "no"
@@ -147,8 +145,6 @@ services:
     restart: "no"
   decision-report-generation:
     restart: "no"
-    environment:
-      - NODE_ENV=development
   shortlist:
     restart: "no"
   signflow-status-sync:
@@ -165,8 +161,6 @@ services:
     restart: "no"
   minutes-report-generation:
     restart: "no"
-    environment:
-      - NODE_ENV=development
   html-to-pdf:
     restart: "no"
   digital-signing:
@@ -183,9 +177,5 @@ services:
     restart: "no"
   draft-file:
     restart: "no"
-    environment:
-      - NODE_ENV=development
   draft-file-mover:
     restart: "no"
-    environment:
-      - NODE_ENV=development

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -123,8 +123,6 @@ services:
   delta-producer:
     image: lblod/sink-service:1.0.0
     restart: "no"
-  delta-consumer:
-    image: lblod/sink-service:1.0.0
     restart: "no"
   fileshare:
     image: lblod/sink-service:1.0.0


### PR DESCRIPTION
Remove `NODE_ENV=development` from services in `docker-compose.development.yml`. I assume these are all committed by accident during development, but they shouldn't be there permanently.