### PR TITLE
Disable checkpoint audit trail in Virtuoso config

### DIFF
--- a/config/db/virtuoso.ini
+++ b/config/db/virtuoso.ini
@@ -24,7 +24,7 @@
 DatabaseFile       = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.db
 ErrorLogFile       = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.log
 LockFile           = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.lck
-TransactionFile    = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso20191009072200.trx
+TransactionFile    = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.trx
 xa_persistent_file = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.pxa
 ErrorLogLevel      = 7
 FileExtend         = 200

--- a/config/db/virtuoso.production.ini
+++ b/config/db/virtuoso.production.ini
@@ -24,7 +24,7 @@
 DatabaseFile       = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.db
 ErrorLogFile       = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.log
 LockFile           = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.lck
-TransactionFile    = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso20220813082542.trx
+TransactionFile    = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.trx
 xa_persistent_file = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.pxa
 ErrorLogLevel      = 7
 FileExtend         = 200
@@ -60,7 +60,7 @@ CheckpointInterval         = 60
 O_DIRECT                   = 0
 CaseMode                   = 2
 MaxStaticCursorRows        = 5000
-CheckpointAuditTrail       = 1
+CheckpointAuditTrail       = 0
 AllowOSCalls               = 0
 SchedulerInterval          = 10
 DirsAllowed                = ., /usr/local/virtuoso-opensource/share/virtuoso/vad


### PR DESCRIPTION
Audit trail has been disabled on all servers. Better to commit this change in the repos to avoid outstanding changes on the server.