### PR TITLE
Add restart no policy on all services in development

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -119,6 +119,7 @@ services:
   publication-report:
     restart: "no"
   decision-extraction:
+    restart: "no"
   delta-producer:
     image: lblod/sink-service:1.0.0
     restart: "no"
@@ -160,10 +161,14 @@ services:
   html-to-pdf:
     restart: "no"
   digital-signing:
+    restart: "no"
     environment:
-      NODE_ENV: "development"
       SIGNINGHUB_API_URL: "https://fake.api.url"
   pdf-flattener:
+    restart: "no"
+  pdf-signature-remover:
+    restart: "no"
+  vlaams-parlement-sync:
     restart: "no"
   agenda-submission:
     restart: "no"


### PR DESCRIPTION
Restart policy of some services was not overwritten yet in `docker-compose.development.yml`.