### PR TITLE
KAS-3597 Search upgrade and connection pooling

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -129,6 +129,9 @@ services:
   #   image: docker.elastic.co/kibana/kibana:7.17.0
   #   environment:
   #     ELASTICSEARCH_URL: "http://elasticsearch:9200"
+  #   user: root
+  #   command: |
+  #     sh -c "/usr/local/bin/kibana-docker --allow-root;"
   #   logging: *default-logging
   #   ports:
   #     - "5601:5601"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,10 +90,9 @@ services:
     labels:
       - "logging=true"
   elasticsearch:
-    image: semtech/mu-search-elastic-backend:1.1.0
+    image: semtech/mu-search-elastic-backend:1.2.0
     environment:
       discovery.type: "single-node"
-      LOG_SCOPE_ELASTICSEARCH: "warn"
     volumes:
       - ./data/elasticsearch/:/usr/share/elasticsearch/data
     logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     logging: *default-logging
     restart: always
   tika:
-    image: apache/tika:1.24-full
+    image: semtech/mu-search-tika-backend:1.0.0
     logging: *default-logging
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     labels:
       - "logging=true"
   search:
-    image: semtech/mu-search:0.10.0
+    image: semtech/mu-search:feature-tika-connection-pool
     volumes:
       - ./config/search:/config
       - ./data/files:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     labels:
       - "logging=true"
   search:
-    image: semtech/mu-search:feature-tika-connection-pool
+    image: semtech/mu-search:0.11.0
     volumes:
       - ./config/search:/config
       - ./data/files:/data


### PR DESCRIPTION
Upgrades of 
- mu-search
- Elasticsearch
- Tika

New release of mu-search introduces connection pooling on requests to Tika/ES/triplestore which put a less heavy load on the Docker networking which sometimes lead to connection errors.

Bump of Tika to v3 has better support for OCR. More configurable OCR options still need to be implemented in mu-search in follow-up stories. OCR behaviour is now still the same as before.