### PR TITLE
Disable usage of CONSTRUCT queries in sparql-parser

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -7,6 +7,11 @@
 
 (setf *log-delta-messenger-message-bus-processing* nil)
 
+;; Disable usage of CONSTRUCT queries on INSERT/DELETE
+;; since it cannot handle OPTIONAL in the WHERE clause
+(in-package #:handle-update-unit)
+(setf *allow-construct-query-p* nil)
+
 ;;;;;;;;;;;;;;;;;
 ;;; configuration
 (in-package :client)


### PR DESCRIPTION
This PR should be merged to development and acceptance to fix database issues until a better `sparql-parser` version comes out.
