### PR TITLE
KAS-4997 add model, dispatcher, auth config

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -214,6 +214,7 @@
 (define-graph kanselarij ("http://mu.semte.ch/graphs/organizations/kanselarij")
   ("ext:Nieuwsbericht" -> _)
   ("ext:MailCampagne" -> _)
+  ("ext:BelgaPublicatie" -> _)
   ("prov:Activity" -> _)
   ("ext:InternalDecisionPublicationActivity" -> _)
   ("ext:InternalDocumentPublicationActivity" -> _)

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -459,6 +459,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/mail-campaigns/"
   end
 
+  match "/belga-publications/*path", @json_service do
+    Proxy.forward conn, path, "http://cache/belga-publications/"
+  end
+
   match "/file-bundling-jobs/*path", @json_service do
     Proxy.forward conn, path, "http://cache/file-bundling-jobs/"
   end

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -196,15 +196,15 @@
                                            :as "themis-publication-activities")
               (submission                :via ,(s-prefix "subm:ingediendVoorVergadering")
                                          :inverse t
-                                         :as "submissions"))
+                                         :as "submissions")
+              (belga-publication        :via      ,(s-prefix "ext:heeftBelgaPublicatie")
+                                        :as "belga-publications"))
   :has-one `((agenda                    :via      ,(s-prefix "besluitvorming:behandelt") ;; Final agenda version that is treatened during the meeting
                                         :as "agenda")
               ;; (piece                    :via ,(s-prefix "dossier:genereert") ;; this relation exists in legacy data, but we do not show this in the frontend currently
               ;;                           :as "notes") ;; note: is this a hasOne or hasMany ?
              (mail-campaign             :via      ,(s-prefix "ext:heeftMailCampagnes")
                                         :as "mail-campaign")
-             (belga-publication         :via      ,(s-prefix "ext:heeftBelgaPublicatie")
-                                        :as "belga-publication")
              (concept                   :via      ,(s-prefix "dct:type")
                                         :as "kind")
              (mandatee                  :via        ,(s-prefix "ext:secretarisVoorVergadering")

--- a/config/resources/besluit-domain.lisp
+++ b/config/resources/besluit-domain.lisp
@@ -203,6 +203,8 @@
               ;;                           :as "notes") ;; note: is this a hasOne or hasMany ?
              (mail-campaign             :via      ,(s-prefix "ext:heeftMailCampagnes")
                                         :as "mail-campaign")
+             (belga-publication         :via      ,(s-prefix "ext:heeftBelgaPublicatie")
+                                        :as "belga-publication")
              (concept                   :via      ,(s-prefix "dct:type")
                                         :as "kind")
              (mandatee                  :via        ,(s-prefix "ext:secretarisVoorVergadering")

--- a/config/resources/newsletter-domain.json
+++ b/config/resources/newsletter-domain.json
@@ -160,6 +160,28 @@
         "include-uri"
       ],
       "new-resource-base": "http://themis.vlaanderen.be/id/mailcampagne/"
+    },
+    "belga-publications": {
+      "name": "belga-publication",
+      "class": "ext:BelgaPublicatie",
+      "attributes": {
+        "sent-at": {
+          "type": "datetime",
+          "predicate": "ext:isVerstuurdOp"
+        }
+      },
+      "relationships": {
+        "meeting": {
+          "target": "meeting",
+          "predicate": "ext:heeftBelgaPublicatie",
+          "cardinality": "one",
+          "inverse": true
+        }
+      },
+      "features": [
+        "include-uri"
+      ],
+      "new-resource-base": "http://themis.vlaanderen.be/id/belga-publicatie/"
     }
   }
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4997

- added new model to newsletter domain (model is not an activity, no status, no start or end datetime
- added model to meeting model as one-to-one
- added model to auth config
- added dispatcher path for new model

also merge/tag newsletter-service