### PR TITLE
Add metrics service with missing document type/id metrics

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -37,6 +37,10 @@ defmodule Dispatcher do
     forward conn, [], "http://resource/health-checks/"
   end
 
+  get "/metrics", %{ layer: :api } do
+    Proxy.forward conn, [], "http://metrics/metrics"
+  end
+
   ### File conversion
 
   post "/files/:id/convert", @json_service do

--- a/config/metrics/document-metrics.js
+++ b/config/metrics/document-metrics.js
@@ -1,0 +1,75 @@
+import promClient from 'prom-client';
+import { query, sparqlEscapeUri } from 'mu';
+
+new promClient.Gauge({
+  name: 'missing_document_id',
+  help: 'Number of documents without document id',
+  labelNames: ['data_validation', 'data_validation_scope'],
+
+  async collect() {
+    const result = await query(`
+    PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+    SELECT (COUNT(?piece) as ?count)
+    FROM <http://mu.semte.ch/graphs/organizations/kanselarij>
+    WHERE {
+      ?documentContainer a dossier:Serie .
+      ?documentContainer dossier:Collectie.bestaatUit ?piece .
+      FILTER NOT EXISTS { ?piece mu:uuid ?id . }
+    }`, { sudo: true });
+    const count = parseInt(result.results.bindings[0]['count'].value);
+    this.labels({ data_validation: 1, data_validation_scope: 'documents'}).set(count);
+  }
+});
+
+new promClient.Gauge({
+  name: 'missing_document_type',
+  help: 'Number of documents without document types',
+  labelNames: ['data_validation', 'data_validation_scope'],
+
+  async collect() {
+    const result = await query(`
+    PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+
+    SELECT (COUNT(?piece) as ?count)
+    FROM <http://mu.semte.ch/graphs/organizations/kanselarij>
+    WHERE {
+      ?documentContainer a dossier:Serie .
+      ?documentContainer dossier:Collectie.bestaatUit ?piece .
+      FILTER NOT EXISTS { ?piece a ?type . }
+    }`, { sudo: true });
+    const count = parseInt(result.results.bindings[0]['count'].value);
+    this.labels({ data_validation: 1, data_validation_scope: 'documents'}).set(count);
+  }
+});
+
+new promClient.Gauge({
+  name: 'document_counts',
+  help: 'Number of documents per graph',
+  labelNames: ['data_validation', 'data_validation_scope', 'graph'],
+
+  async collect() {
+    const graphs = [
+      'http://mu.semte.ch/graphs/organizations/kanselarij',
+      'http://mu.semte.ch/graphs/organizations/minister',
+      'http://mu.semte.ch/graphs/organizations/intern-regering',
+      'http://mu.semte.ch/graphs/organizations/intern-overheid',
+    ];
+    for (let graph of graphs) {
+      const result = await query(`
+        PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+        SELECT (COUNT(?piece) as ?count)
+        FROM ${sparqlEscapeUri(graph)}
+        WHERE {
+          ?piece a dossier:Stuk .
+        }`, { sudo: true });
+      const count = parseInt(result.results.bindings[0]['count'].value);
+      this.labels({ data_validation: 1, data_validation_scope: 'documents', graph }).set(count);
+    }
+  }
+});
+
+export default [];

--- a/config/metrics/index.js
+++ b/config/metrics/index.js
@@ -1,0 +1,3 @@
+import documentMetrics from './document-metrics';
+
+export default [...documentMetrics];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -529,3 +529,10 @@ services:
     restart: always
     labels:
       - "logging=true"
+  metrics:
+    image: lblod/metrics-service:0.2.0
+    environment:
+      ALLOW_MU_AUTH_SUDO: "true"
+    volumes:
+      - ./config/metrics:/config
+      - ./data/metrics:/external-metrics


### PR DESCRIPTION
Attempt to use https://github.com/lblod/metrics-service to collect metrics about documents
Alternative for #554 

Using the integration with Prometheus, we will be able to visualize the metrics in a Grafana dashboard and have more flexibility to configure alerts per metric.

The following configuration must be added to `./config/prometheus/prometheus.yml` to scrape the metrics
```yaml
scrape_configs:
  - job_name: "kaleidos-metrics"
    scrape_interval: 15m
    static_configs:
      - targets:
        - "kaleidos.vlaanderen.be"
        labels:
          environment: "production"
```

Example output of the endpoint
```
# HELP missing_document_id Number of documents without document id
# TYPE missing_document_id gauge
missing_document_id{data_validation="1",data_validation_scope="documents"} 0

# HELP missing_document_type Number of documents without document types
# TYPE missing_document_type gauge
missing_document_type{data_validation="1",data_validation_scope="documents"} 0

# HELP document_counts Number of documents per graph
# TYPE document_counts gauge
document_counts{data_validation="1",data_validation_scope="documents",graph="http://mu.semte.ch/graphs/organizations/kanselarij"} 323204
document_counts{data_validation="1",data_validation_scope="documents",graph="http://mu.semte.ch/graphs/organizations/minister"} 284887
document_counts{data_validation="1",data_validation_scope="documents",graph="http://mu.semte.ch/graphs/organizations/intern-regering"} 284887
document_counts{data_validation="1",data_validation_scope="documents",graph="http://mu.semte.ch/graphs/organizations/intern-overheid"} 283712
```

The following configuration must be added in `./config/prometheus/rules/alert-rules.yml` to trigger alerts
```yaml
groups:
- name: data-validations
  rules:
    - alert: MissingDocumentId
      expr: missing_document_id > 0
      for: 5m
      labels:
        severity: warning
      annotations:
        summary: "Missing document ID detected"
        description: "There are {{ $value }} documents without an ID in the triplestore"
    - alert: MissingDocumentType
      expr: missing_document_type > 0
      for: 5m
      labels:
        severity: warning
      annotations:
        summary: "Missing document type detected"
        description: "There are {{ $value }} documents without a type in the triplestore"
```

The following configuration must be added in `./config/alertmanager/alertmanager.yml` to send notifications
```yaml
  routes:
    - receiver: kal-notifications
      matchers:
        - data_validation = 1
        - severity = warning
      repeat_interval: 1h
      continue: false
```

To try out on your local machine, spin up a monitoring stack using https://github.com/redpencilio/app-server-monitor
and add the following to `./config/prometheus/prometheus.yml`

```yaml
scrape_configs:
  - job_name: "kaleidos-metrics"
    static_configs:
      - targets:
        - "172.17.0.1"   # IP to access host machine from inside a docker container
```

This will start scraping the metrics each 15 seconds. 
You can inspect them via Grafana on http://localhost:3000 > Drilldown > Metrics