### PR TITLE
KAS-5210 add data-monitoring service to stack

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -475,6 +475,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/jobs/"
   end
 
+  get "/distributor-jobs/*path", @json_service do
+    Proxy.forward conn, path, "http://cache/distributor-jobs/"
+  end
+
   # PUBLICATION-FLOW
   match "/publication-flows/search/*path", @json_service do
     Proxy.forward conn, path, "http://search/publication-flows/search/"

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -699,6 +699,11 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://pdf-signature-remover/pieces/" <> piece_id <> "/strip"
   end
 
+  ### Data Monitoring
+  get "/data-monitoring/*path", @json_service do
+    Proxy.forward conn, path, "http://data-monitoring/"
+  end
+
   ## Fallback
 
   get "/*_path", %{ layer: :api, accept: %{ html: true } } do

--- a/config/resources/job-domain.lisp
+++ b/config/resources/job-domain.lisp
@@ -60,3 +60,22 @@
   :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatierapporttype/")
   :features '(include-uri)
   :on-path "publication-report-types")
+
+
+
+
+;; TODO KAS-4883 this will conflict
+(define-resource distributor-job () ;; cogs:Job only in spirit, using inheritance may cause isses on prov:used
+  :class (s-prefix "ext:DistributorJob")
+  :properties `((:created       :datetime  ,(s-prefix "dct:created"))
+                (:status        :url       ,(s-prefix "adms:status"))
+                (:time-started  :datetime  ,(s-prefix "prov:startedAtTime"))
+                (:time-ended    :datetime  ,(s-prefix "prov:endedAtTime"))
+                (:message       :string    ,(s-prefix "schema:error"))
+                (:target-graph  :url       ,(s-prefix "ext:targetGraph")))
+  :has-many `((agenda           :via       ,(s-prefix "prov:used") ;; prov:used may cause inheritance issues
+                                :as "agendas"))
+
+  :resource-base (s-url "http://mu.semte.ch/services/yggdrasil/distributor-jobs")
+  :features '(include-uri)
+  :on-path "distributor-jobs")

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -183,3 +183,6 @@ services:
     restart: "no"
   draft-file-mover:
     restart: "no"
+  data-monitoring:
+    entrypoint: "echo 'service disabled'"
+    restart: "no"

--- a/docker-compose.mirror.yml
+++ b/docker-compose.mirror.yml
@@ -153,3 +153,5 @@ services:
     <<: *disabled-for-mirror
   draft-file-mover:
     <<: *disabled-for-mirror
+  data-monitoring:
+    <<: *disabled-for-mirror

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,13 +20,13 @@ services:
       - ./testdata/files:/share
   themis-export:
     volumes:
-      - ./testdata/files:/share
+      - ./testdata/exports:/share
   ttl-to-delta:
     volumes:
       - ./testdata/files:/share
   export-file:
     volumes:
-      - ./testdata/files:/share
+      - ./testdata/exports:/share
   # docx-conversion:
   # old version that uses libreoffice for conversion instead of azure
     # image: kanselarij/docx-conversion-service:0.1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -530,3 +530,16 @@ services:
     restart: always
     labels:
       - "logging=true"
+  data-monitoring:
+    image: kanselarij/data-monitoring-service:feature-KAS-5210-data-monitoring-kaleidos-themis
+    environment:
+      KALEIDOS_HOST_URL: "https://kaleidos-dev.vlaanderen.be/" # how to know what server or host sent the email
+      POLLING_CRON_PATTERN: "0 * 4-22 * * *" # how often we poll for issues
+      EMAIL_TO_ADDRESS_ON_FAILURE: "" # recipients of the emails. If left blank no emails will be created
+      THEMIS_ENDPOINT_URL: "https://themis-dev.vlaanderen.be"
+    logging: *default-logging
+    restart: always
+    labels:
+      - "logging=true"
+
+# if a new service is added, update the docker-compose.mirror.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -416,7 +416,7 @@ services:
     restart: always
     logging: *default-logging
   themis-export:
-    image: kanselarij/themis-export-service:feature-KAS-5210-data-monitoring-kaleidos-themis
+    image: kanselarij/themis-export-service:3.3.0
     environment:
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql" # database for results for which delta's must be generated
       VIRTUOSO_SPARQL_ENDPOINT: "http://triplestore:8890/sparql" # database for intermediate results and to export data from
@@ -427,7 +427,7 @@ services:
     restart: always
     logging: *default-logging
   ttl-to-delta:
-    image: kanselarij/ttl-to-delta-service:feature-KAS-5210-data-monitoring-kaleidos-themis
+    image: kanselarij/ttl-to-delta-service:1.1.0
     environment:
       TASK_GRAPH: "http://mu.semte.ch/graphs/themis-public"
       FILE_GRAPH: "http://mu.semte.ch/graphs/themis-public"
@@ -438,7 +438,7 @@ services:
     restart: always
     logging: *default-logging
   publication-producer:
-    image: kanselarij/themis-publication-producer:feature-KAS-5210-data-monitoring-kaleidos-themis
+    image: kanselarij/themis-publication-producer:1.2.0
     labels:
       - "logging=true"
     restart: always
@@ -531,7 +531,7 @@ services:
     labels:
       - "logging=true"
   data-monitoring:
-    image: kanselarij/data-monitoring-service:feature-KAS-5210-data-monitoring-kaleidos-themis
+    image: kanselarij/data-monitoring-service:1.0.0
     environment:
       KALEIDOS_HOST_URL: "https://kaleidos-dev.vlaanderen.be/" # how to know what server or host sent the email
       POLLING_CRON_PATTERN: "0 * 4-22 * * *" # how often we poll for issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,7 @@ services:
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:5.26.1
+    image: kanselarij/yggdrasil:5.27.0
     logging: *default-logging
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -416,7 +416,7 @@ services:
     restart: always
     logging: *default-logging
   themis-export:
-    image: kanselarij/themis-export-service:3.2.1
+    image: kanselarij/themis-export-service:feature-KAS-5210-data-monitoring-kaleidos-themis
     environment:
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql" # database for results for which delta's must be generated
       VIRTUOSO_SPARQL_ENDPOINT: "http://triplestore:8890/sparql" # database for intermediate results and to export data from
@@ -427,7 +427,7 @@ services:
     restart: always
     logging: *default-logging
   ttl-to-delta:
-    image: redpencil/ttl-to-delta:1.0.1
+    image: kanselarij/ttl-to-delta-service:feature-KAS-5210-data-monitoring-kaleidos-themis
     environment:
       TASK_GRAPH: "http://mu.semte.ch/graphs/themis-public"
       FILE_GRAPH: "http://mu.semte.ch/graphs/themis-public"
@@ -438,7 +438,7 @@ services:
     restart: always
     logging: *default-logging
   publication-producer:
-    image: kanselarij/themis-publication-producer:1.1.2
+    image: kanselarij/themis-publication-producer:feature-KAS-5210-data-monitoring-kaleidos-themis
     labels:
       - "logging=true"
     restart: always
@@ -536,7 +536,7 @@ services:
       KALEIDOS_HOST_URL: "https://kaleidos-dev.vlaanderen.be/" # how to know what server or host sent the email
       POLLING_CRON_PATTERN: "0 * 4-22 * * *" # how often we poll for issues
       EMAIL_TO_ADDRESS_ON_FAILURE: "" # recipients of the emails. If left blank no emails will be created
-      THEMIS_ENDPOINT_URL: "https://themis-dev.vlaanderen.be"
+      THEMIS_ENDPOINT_URL: "https://themis-dev.kanselarij.org/"
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5210

New service added to stack
Disabled for mirror
The env properties for emails may get deleted (using mails not confirmed, might be replaced with the metrics PR suggestion)
Fixed incorrect paths for test.yml

Service bumps needed:
`themis-export`
`ttl-to-delta`
`publication-producer`