### PR TITLE
Feature/kas 5211 data propagation dashboard

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -475,6 +475,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/jobs/"
   end
 
+  get "/distributor-jobs/*path", @json_service do
+    Proxy.forward conn, path, "http://cache/distributor-jobs/"
+  end
+
   # PUBLICATION-FLOW
   match "/publication-flows/search/*path", @json_service do
     Proxy.forward conn, path, "http://search/publication-flows/search/"

--- a/config/resources/job-domain.lisp
+++ b/config/resources/job-domain.lisp
@@ -60,3 +60,22 @@
   :resource-base (s-url "http://themis.vlaanderen.be/id/concept/publicatierapporttype/")
   :features '(include-uri)
   :on-path "publication-report-types")
+
+
+
+
+;; TODO KAS-4883 this will conflict
+(define-resource distributor-job () ;; cogs:Job only in spirit, using inheritance may cause isses on prov:used
+  :class (s-prefix "ext:DistributorJob")
+  :properties `((:created       :datetime  ,(s-prefix "dct:created"))
+                (:status        :url       ,(s-prefix "adms:status"))
+                (:time-started  :datetime  ,(s-prefix "prov:startedAtTime"))
+                (:time-ended    :datetime  ,(s-prefix "prov:endedAtTime"))
+                (:message       :string    ,(s-prefix "schema:error"))
+                (:target-graph  :url       ,(s-prefix "ext:targetGraph")))
+  :has-many `((agenda           :via       ,(s-prefix "prov:used") ;; prov:used may cause inheritance issues
+                                :as "agendas"))
+
+  :resource-base (s-url "http://mu.semte.ch/services/yggdrasil/distributor-jobs")
+  :features '(include-uri)
+  :on-path "distributor-jobs")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,7 @@ services:
     labels:
       - "logging=true"
   yggdrasil:
-    image: kanselarij/yggdrasil:5.26.1
+    image: kanselarij/yggdrasil:5.27.0
     logging: *default-logging
     restart: always
     labels:


### PR DESCRIPTION
## started from KAS-5210 > started from acceptance

https://kanselarij.atlassian.net/browse/KAS-5209
related (needs yggdrasil code) of:
https://kanselarij.atlassian.net/browse/KAS-5211

Backend for data propagation dashboard
- added dispatcher route for model
- added model