### PR TITLE
Make contact persons be able to be linked to multiple publication flows

### DIFF
--- a/config/resources/publicatie-domain.json
+++ b/config/resources/publicatie-domain.json
@@ -668,10 +668,10 @@
           "cardinality": "one",
           "inverse": true
         },
-        "publication-flow": {
+        "publication-flows": {
           "predicate": "prov:qualifiedDelegation",
           "target": "publication-flow",
-          "cardinality": "one",
+          "cardinality": "many",
           "inverse": true
         }
       },


### PR DESCRIPTION
Make contact persons be able to be linked to multiple publication flows, so we can reuse them instead of creating new ones everytime.

https://kanselarij.atlassian.net/jira/software/c/projects/KAS/boards/1?selectedIssue=KAS-3388