### PR TITLE
Upgrade Virtuoso to disable built-in HTTP client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     labels:
       - "logging=true"
   triplestore:
-    image: redpencil/virtuoso:1.2.1
+    image: redpencil/virtuoso:1.2.2
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
Patch upgrade of Virtuoso. New version disables the built-in HTTP client.

Custom Jenkins build: https://ci.kanselarij.org/job/Kaleidos/job/custom-combo/21/