### PR TITLE
Add migration to remove duplicate organizations and have 1 canonical left

### DIFF
--- a/config/migrations/20260611100000-merge-duplicate-organizations.sparql
+++ b/config/migrations/20260611100000-merge-duplicate-organizations.sparql
@@ -1,0 +1,67 @@
+# KAS-3389
+
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX org:  <http://www.w3.org/ns/org#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
+
+# redirect outgoing triples from duplicates to canonicals.
+DELETE {
+  GRAPH ?graph { ?dup ?predicate ?object . }
+}
+INSERT {
+  GRAPH ?graph { ?canonical ?predicate ?object . }
+}
+WHERE {
+  {
+    SELECT ?name ?identifier (MIN(STR(?org)) AS ?canonicalStr)
+    WHERE {
+      ?org a org:Organization ; skos:prefLabel ?name .
+      OPTIONAL { ?org org:identifier ?identifierOpt }
+      BIND(COALESCE(?identifierOpt, "") AS ?identifier)
+    }
+    GROUP BY ?name ?identifier
+    HAVING (COUNT(?org) > 1)
+  }
+  BIND(IRI(?canonicalStr) AS ?canonical)
+  ?dup a org:Organization ; skos:prefLabel ?name .
+  OPTIONAL { ?dup org:identifier ?dupIdentifierOpt }
+  BIND(COALESCE(?dupIdentifierOpt, "") AS ?dupIdentifier)
+  FILTER (?dupIdentifier = ?identifier)
+  FILTER (?dup != ?canonical)
+  GRAPH ?graph {
+    ?dup ?predicate ?object .
+    FILTER (?predicate NOT IN (
+      rdf:type,
+      mu:uuid,
+      skos:prefLabel,
+      org:identifier
+    ))
+  }
+};
+
+# delete each duplicate's remaining (identity) triples.
+DELETE {
+  GRAPH ?graph { ?dup ?predicate ?object . }
+}
+WHERE {
+  {
+    SELECT ?name ?identifier (MIN(STR(?org)) AS ?canonicalStr)
+    WHERE {
+      ?org a org:Organization ; skos:prefLabel ?name .
+      OPTIONAL { ?org org:identifier ?identifierOpt }
+      BIND(COALESCE(?identifierOpt, "") AS ?identifier)
+    }
+    GROUP BY ?name ?identifier
+    HAVING (COUNT(?org) > 1)
+  }
+  BIND(IRI(?canonicalStr) AS ?canonical)
+  ?dup a org:Organization ; skos:prefLabel ?name .
+  OPTIONAL { ?dup org:identifier ?dupIdentifierOpt }
+  BIND(COALESCE(?dupIdentifierOpt, "") AS ?dupIdentifier)
+  FILTER (?dupIdentifier = ?identifier)
+  FILTER (?dup != ?canonical)
+  GRAPH ?graph {
+    ?dup ?predicate ?object .
+  }
+};


### PR DESCRIPTION
For the deploy of https://kanselarij.atlassian.net/browse/KAS-3388 / https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/2416 , we need to make sure all the old duplicate organizations are gone.
This migration aims to do that.

It will rewrite all linked triples, so the relationship will be linking to the canonical.

We can query for the remaining duplicates after the migration with this query:

```
PREFIX org:  <http://www.w3.org/ns/org#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>

SELECT ?name ?org ?uuid ?identifier ?g
WHERE {
  {
    SELECT ?name
    WHERE {
      GRAPH ?g {
        ?o a org:Organization ;
           skos:prefLabel ?name .
      }
    }
    GROUP BY ?name
    HAVING (COUNT(DISTINCT ?o) > 1)
  }
  GRAPH ?g {
    ?org a org:Organization ;
         skos:prefLabel ?name ;
         mu:uuid ?uuid .
    OPTIONAL { ?org org:identifier ?identifier }
  }
}
ORDER BY ?name ?org
```

These would be the ones that for example, have the same name but different identifiers. We will need to ask Kanselarij to pick between these manually.