### PR TITLE
Add migration to trim cases titles

### DIFF
--- a/config/migrations/20260611110000-trim-dossier-short-title-whitespace.sparql
+++ b/config/migrations/20260611110000-trim-dossier-short-title-whitespace.sparql
@@ -1,0 +1,19 @@
+# Strip leading/trailing whitespace from dossier short titles.
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX dct:     <http://purl.org/dc/terms/>
+
+DELETE {
+  GRAPH ?graph { ?case dct:alternative ?title . }
+}
+INSERT {
+  GRAPH ?graph { ?case dct:alternative ?trimmedTitle . }
+}
+WHERE {
+  GRAPH ?graph {
+    ?case a dossier:Dossier ;
+          dct:alternative ?title .
+  }
+
+  BIND(REPLACE(?title, "^\\s+|\\s+$", "") AS ?trimmedTitle)
+  FILTER(STR(?title) != STR(?trimmedTitle))
+};


### PR DESCRIPTION
Migration to remove whitelines from the beginning/end of shortitles of cases (alternativetitle), so the ordering will work properly again.

https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/2417 will prevent titles being created with newlines in the future.